### PR TITLE
Rewrite character sheet page

### DIFF
--- a/Finmer.Game/Converters/CharSheetItemDropConverter.cs
+++ b/Finmer.Game/Converters/CharSheetItemDropConverter.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * FINMER - Interactive Text Adventure
+ * Copyright (C) 2019-2021 Nuntis the Wolf.
+ *
+ * Licensed under the GNU General Public License v3.0 (GPL3). See LICENSE.md for details.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Finmer.Gameplay;
+
+namespace Finmer.Converters
+{
+
+    /// <summary>
+    /// Converter that takes an Item and returns a boolean indicating whether this Item may be freely deleted from the inventory.
+    /// </summary>
+    internal sealed class CharSheetItemDropConverter : IValueConverter
+    {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            Item item = value as Item;
+
+            // Value may be null in the XAML designer
+            if (item == null)
+                return false;
+
+            // Any item except quest items may be deleted if the player wishes
+            return !item.Asset.IsQuestItem;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+    }
+
+}

--- a/Finmer.Game/Converters/CharSheetItemUseConverter.cs
+++ b/Finmer.Game/Converters/CharSheetItemUseConverter.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * FINMER - Interactive Text Adventure
+ * Copyright (C) 2019-2021 Nuntis the Wolf.
+ *
+ * Licensed under the GNU General Public License v3.0 (GPL3). See LICENSE.md for details.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Finmer.Core.Assets;
+using Finmer.Gameplay;
+
+namespace Finmer.Converters
+{
+
+    /// <summary>
+    /// Converter that takes an Item and returns a boolean indicating whether this Item can be 'used' from the character sheet.
+    /// </summary>
+    internal sealed class CharSheetItemUseConverter : IValueConverter
+    {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            Item item = value as Item;
+
+            // Value may be null in the XAML designer
+            if (item == null)
+                return false;
+
+            // Usable-type items as well as equipable items can be 'used' from the character sheet
+            switch (item.Asset.ItemType)
+            {
+                case AssetItem.EItemType.Usable:
+                    return item.Asset.CanUseInField;
+
+                default:
+                    return false;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+    }
+
+}

--- a/Finmer.Game/Converters/CharSheetUseLabelConverter.cs
+++ b/Finmer.Game/Converters/CharSheetUseLabelConverter.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * FINMER - Interactive Text Adventure
+ * Copyright (C) 2019-2021 Nuntis the Wolf.
+ *
+ * Licensed under the GNU General Public License v3.0 (GPL3). See LICENSE.md for details.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Finmer.Core.Assets;
+using Finmer.Gameplay;
+
+namespace Finmer.Converters
+{
+
+    /// <summary>
+    /// Converter that takes an Item and returns a string appropriate for display on the Use button.
+    /// </summary>
+    internal sealed class CharSheetUseLabelConverter : IValueConverter
+    {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            Item item = value as Item;
+
+            // Value may be null in the XAML designer
+            if (item == null)
+                return "???";
+
+            // Usable-type items as well as equipable items can be 'used' from the character sheet
+            switch (item.Asset.ItemType)
+            {
+                case AssetItem.EItemType.Usable:
+                    if (item.Asset.CanUseInBattle && !item.Asset.CanUseInField)
+                        return "In combat only";
+
+                    return "Use";
+
+                case AssetItem.EItemType.Weapon:
+                case AssetItem.EItemType.Armor:
+                    return "Equip";
+
+                default:
+                    return "Can't use";
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+    }
+
+}

--- a/Finmer.Game/Finmer.csproj
+++ b/Finmer.Game/Finmer.csproj
@@ -174,8 +174,8 @@
     <Compile Include="Views\GameOverPanelView.xaml.cs">
       <DependentUpon>GameOverPanelView.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\ItemBoxView.xaml.cs">
-      <DependentUpon>ItemBoxView.xaml</DependentUpon>
+    <Compile Include="Views\ItemEquipmentBoxView.xaml.cs">
+      <DependentUpon>ItemEquipmentBoxView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\JournalListItemView.xaml.cs">
       <DependentUpon>JournalListItemView.xaml</DependentUpon>
@@ -306,7 +306,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\ItemBoxView.xaml">
+    <Page Include="Views\ItemEquipmentBoxView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Finmer.Game/Finmer.csproj
+++ b/Finmer.Game/Finmer.csproj
@@ -133,6 +133,9 @@
     <Compile Include="Views\CharCreateBasic.xaml.cs">
       <DependentUpon>CharCreateBasic.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\CharSheetInventoryItemActions.xaml.cs">
+      <DependentUpon>CharSheetInventoryItemActions.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\CharSheetPage.xaml.cs">
       <DependentUpon>CharSheetPage.xaml</DependentUpon>
     </Compile>
@@ -248,6 +251,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\CharCreateBasic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\CharSheetInventoryItemActions.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Finmer.Game/Finmer.csproj
+++ b/Finmer.Game/Finmer.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Models\UserConfig.cs" />
     <Compile Include="ViewModels\AbilityPointViewModel.cs" />
     <Compile Include="ViewModels\BaseProp.cs" />
+    <Compile Include="ViewModels\CharacterSheetViewModel.cs" />
     <Compile Include="ViewModels\CombatRoundPipsViewModel.cs" />
     <Compile Include="ViewModels\CombatStateViewModel.cs" />
     <Compile Include="ViewModels\GameObjectViewModel.cs" />
@@ -230,6 +231,10 @@
     <DesignData Include="Models\DesignData\SampleCharCreateAbility.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </DesignData>
+    <DesignData Include="Models\DesignData\SampleCharacterSheet.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </DesignData>
     <Page Include="Views\CarouselView.xaml">
       <SubType>Designer</SubType>

--- a/Finmer.Game/Finmer.csproj
+++ b/Finmer.Game/Finmer.csproj
@@ -63,6 +63,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Converters\CharSheetItemDropConverter.cs" />
+    <Compile Include="Converters\CharSheetUseLabelConverter.cs" />
+    <Compile Include="Converters\CharSheetItemUseConverter.cs" />
     <Compile Include="Converters\HourToClockAngleConverter.cs" />
     <Compile Include="Converters\CountToListConverter.cs" />
     <Compile Include="Converters\QuantityToVisibilityConverter.cs" />

--- a/Finmer.Game/Models/DesignData/SampleCharacterSheet.xaml
+++ b/Finmer.Game/Models/DesignData/SampleCharacterSheet.xaml
@@ -1,0 +1,12 @@
+﻿<vm:CharacterSheetViewModel
+    xmlns:vm="clr-namespace:Finmer.ViewModels"
+    Name="Food"
+    Species="tasty snack"
+    Level="3"
+    XP="159"
+    RequiredXP="200"
+    Strength="4"
+    Agility="2"
+    Body="4"
+    Wits="1"
+    Money="1234" />

--- a/Finmer.Game/ViewModels/CharacterSheetViewModel.cs
+++ b/Finmer.Game/ViewModels/CharacterSheetViewModel.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * FINMER - Interactive Text Adventure
+ * Copyright (C) 2019-2021 Nuntis the Wolf.
+ *
+ * Licensed under the GNU General Public License v3.0 (GPL3). See LICENSE.md for details.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using Finmer.Gameplay;
+using Finmer.Utility;
+
+namespace Finmer.ViewModels
+{
+
+    /// <summary>
+    /// View model for the character sheet page.
+    /// </summary>
+    internal sealed class CharacterSheetViewModel : BaseProp
+    {
+
+        private Player Player { get; }
+
+        public JournalViewModel JournalViewModel => m_JournalViewModel ?? (m_JournalViewModel = new JournalViewModel(Player.Journal));
+
+        public ICommand IncreaseAbilityCommand => m_IncreaseAbilityCmd ?? (m_IncreaseAbilityCmd = new RelayCommand(SpendAbilityPoint));
+
+        public Visibility AbilityPointVisibility => AbilityPoints > 0 ? Visibility.Visible : Visibility.Hidden;
+
+        public Visibility PreyVisibility => Player.StomachFullness > 0f ? Visibility.Visible : Visibility.Collapsed;
+
+        public string Name => Player.Name;
+
+        public string Species => Player.Species;
+
+        public int Strength => Player.Strength;
+
+        public int Agility => Player.Agility;
+
+        public int Body => Player.Body;
+
+        public int Wits => Player.Wits;
+
+        public int Level => Player.Level;
+
+        public int XP => Player.XP;
+
+        public int RequiredXP => Player.RequiredXP;
+
+        public int Money => Player.Money;
+
+        public int AbilityPoints => Player.AbilityPoints;
+
+        public string PreyList => String.Join(", ", Player.Stomach.Select(prey => prey.Name));
+
+        public List<Item> Inventory => Player.Inventory;
+
+        public Item[] Equipment => Player.Equipment;
+
+        private ICommand m_IncreaseAbilityCmd;
+
+        private JournalViewModel m_JournalViewModel;
+
+        public CharacterSheetViewModel(Player player)
+        {
+            Player = player;
+        }
+
+        private void SpendAbilityPoint(object args)
+        {
+            int stat_index = Int32.Parse((string)args);
+
+            // Validate that there is actually an ability point to spend
+            if (Player.AbilityPoints < 1)
+                return;
+
+            // Take away the point
+            Player.AbilityPoints--;
+
+            // Increase the stat of choice
+            switch (stat_index)
+            {
+                case 0:     Player.Strength++;      OnPropertyChanged(nameof(Strength));        break;
+                case 1:     Player.Agility++;       OnPropertyChanged(nameof(Agility));         break;
+                case 2:     Player.Body++;          OnPropertyChanged(nameof(Body));            break;
+                case 3:     Player.Wits++;          OnPropertyChanged(nameof(Wits));            break;
+            }
+
+            OnPropertyChanged(nameof(AbilityPoints));
+            OnPropertyChanged(nameof(AbilityPointVisibility));
+        }
+    }
+
+}

--- a/Finmer.Game/ViewModels/CharacterSheetViewModel.cs
+++ b/Finmer.Game/ViewModels/CharacterSheetViewModel.cs
@@ -8,6 +8,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
@@ -27,7 +29,11 @@ namespace Finmer.ViewModels
 
         public JournalViewModel JournalViewModel => m_JournalViewModel ?? (m_JournalViewModel = new JournalViewModel(Player.Journal));
 
-        public ICommand IncreaseAbilityCommand => m_IncreaseAbilityCmd ?? (m_IncreaseAbilityCmd = new RelayCommand(SpendAbilityPoint));
+        public ICommand UseItemCommand => m_UseItemCommand ?? (m_UseItemCommand = new RelayCommand(UseItem));
+
+        public ICommand DropItemCommand => m_DropItemCommand ?? (m_DropItemCommand = new RelayCommand(DropItem));
+
+        public ICommand IncreaseAbilityCommand => m_IncreaseAbilityCommand ?? (m_IncreaseAbilityCommand = new RelayCommand(SpendAbilityPoint));
 
         public Visibility AbilityPointVisibility => AbilityPoints > 0 ? Visibility.Visible : Visibility.Hidden;
 
@@ -57,17 +63,19 @@ namespace Finmer.ViewModels
 
         public string PreyList => String.Join(", ", Player.Stomach.Select(prey => prey.Name));
 
-        public List<Item> Inventory => Player.Inventory;
+        public ObservableCollection<Item> Inventory { get; }
 
         public Item[] Equipment => Player.Equipment;
 
-        private ICommand m_IncreaseAbilityCmd;
-
+        private ICommand m_UseItemCommand;
+        private ICommand m_DropItemCommand;
+        private ICommand m_IncreaseAbilityCommand;
         private JournalViewModel m_JournalViewModel;
 
         public CharacterSheetViewModel(Player player)
         {
             Player = player;
+            Inventory = new ObservableCollection<Item>(Player.Inventory);
         }
 
         private void SpendAbilityPoint(object args)
@@ -93,6 +101,25 @@ namespace Finmer.ViewModels
             OnPropertyChanged(nameof(AbilityPoints));
             OnPropertyChanged(nameof(AbilityPointVisibility));
         }
+
+        private void UseItem(object arg)
+        {
+            Item item = (Item)arg;
+
+            // TODO: Invoke item use script / swap equipment
+            Debug.WriteLine(item);
+        }
+
+        private void DropItem(object arg)
+        {
+            // Remove the item from the character sheet. This will notify the view to update.
+            Item item = (Item)arg;
+            Inventory.Remove(item);
+
+            // Remove the item from the real player inventory. This should be safe to do since modifications are made 1:1.
+            Player.Inventory.Remove(item);
+        }
+
     }
 
 }

--- a/Finmer.Game/ViewModels/CharacterSheetViewModel.cs
+++ b/Finmer.Game/ViewModels/CharacterSheetViewModel.cs
@@ -7,7 +7,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
@@ -32,6 +31,8 @@ namespace Finmer.ViewModels
         public ICommand UseItemCommand => m_UseItemCommand ?? (m_UseItemCommand = new RelayCommand(UseItem));
 
         public ICommand DropItemCommand => m_DropItemCommand ?? (m_DropItemCommand = new RelayCommand(DropItem));
+
+        public ICommand UnequipItemCommand => m_UnequipItemCommand ?? (m_UnequipItemCommand = new RelayCommand(UnequipItem));
 
         public ICommand IncreaseAbilityCommand => m_IncreaseAbilityCommand ?? (m_IncreaseAbilityCommand = new RelayCommand(SpendAbilityPoint));
 
@@ -69,6 +70,7 @@ namespace Finmer.ViewModels
 
         private ICommand m_UseItemCommand;
         private ICommand m_DropItemCommand;
+        private ICommand m_UnequipItemCommand;
         private ICommand m_IncreaseAbilityCommand;
         private JournalViewModel m_JournalViewModel;
 
@@ -118,6 +120,25 @@ namespace Finmer.ViewModels
 
             // Remove the item from the real player inventory. This should be safe to do since modifications are made 1:1.
             Player.Inventory.Remove(item);
+        }
+
+        private void UnequipItem(object arg)
+        {
+            // Find the equipped item; validate that the slot actually contains something as a failsafe
+            int equipment_index = (int)arg;
+            Item equipped = Player.Equipment[equipment_index];
+            if (equipped == null)
+                return;
+
+            // Remove the equipped item from the equipment slot
+            Player.Equipment[equipment_index] = null;
+
+            // Make sure to update the equipment box view
+            OnPropertyChanged(nameof(Equipment));
+
+            // Append the item to the end of the inventory
+            Inventory.Add(equipped);
+            Player.Inventory.Add(equipped);
         }
 
     }

--- a/Finmer.Game/Views/CharSheetInventoryItemActions.xaml
+++ b/Finmer.Game/Views/CharSheetInventoryItemActions.xaml
@@ -1,0 +1,68 @@
+﻿<UserControl
+    x:Class="Finmer.Views.CharSheetInventoryItemActions"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:v="clr-namespace:Finmer.Views"
+    xmlns:gp="clr-namespace:Finmer.Gameplay"
+    xmlns:vm="clr-namespace:Finmer.ViewModels"
+    xmlns:cv="clr-namespace:Finmer.Converters"
+    mc:Ignorable="d"
+    d:DesignHeight="100"
+    d:DesignWidth="250">
+    <UserControl.Resources>
+        <cv:CharSheetItemUseConverter x:Key="CharSheetItemUseConverter" />
+        <cv:CharSheetItemDropConverter x:Key="CharSheetItemDropConverter" />
+        <cv:CharSheetUseLabelConverter x:Key="CharSheetUseLabelConverter" />
+    </UserControl.Resources>
+    <!-- Item action buttons -->
+    <Grid
+        d:DataContext="{d:DesignInstance gp:Item}"
+        Margin="8">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <!-- Use/Equip button -->
+        <Button
+            Grid.Column="0"
+            Margin="2"
+            Height="35"
+            Content="{Binding Converter={StaticResource CharSheetUseLabelConverter}}"
+            Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.UseItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
+            CommandParameter="{Binding}"
+            IsEnabled="{Binding Converter={StaticResource CharSheetItemUseConverter}}" />
+        <!-- Drop button -->
+        <ToggleButton
+            Grid.Column="1"
+            x:Name="ItemDropButton"
+            Margin="2"
+            Height="35"
+            Content="Drop"
+            IsEnabled="{Binding Converter={StaticResource CharSheetItemDropConverter}}" />
+        <!-- Drop confirmation popup -->
+        <Popup
+            Grid.Column="1"
+            IsOpen="{Binding IsChecked, Mode=TwoWay, ElementName=ItemDropButton}"
+            MaxWidth="200"
+            StaysOpen="False">
+            <Border Style="{StaticResource PopupBorderStyle}">
+                <StackPanel>
+                    <TextBlock
+                        Style="{StaticResource TextBlockDefault}"
+                        Margin="6,6,6,16"
+                        Text="Are you sure you want to discard this item?"
+                        TextWrapping="Wrap" />
+                    <Button
+                        Height="35"
+                        Content="Confirm Drop"
+                        Foreground="OrangeRed"
+                        Margin="5"
+                        Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.DropItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
+                        CommandParameter="{Binding}" />
+                </StackPanel>
+            </Border>
+        </Popup>
+    </Grid>
+</UserControl>

--- a/Finmer.Game/Views/CharSheetInventoryItemActions.xaml.cs
+++ b/Finmer.Game/Views/CharSheetInventoryItemActions.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Finmer.Views
+{
+    /// <summary>
+    /// Interaction logic for CharSheetInventoryItemActions.xaml
+    /// </summary>
+    public partial class CharSheetInventoryItemActions : UserControl
+    {
+        public CharSheetInventoryItemActions()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Finmer.Game/Views/CharSheetPage.xaml
+++ b/Finmer.Game/Views/CharSheetPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:cv="clr-namespace:Finmer.Converters"
     xmlns:v="clr-namespace:Finmer.Views"
+    xmlns:gp="clr-namespace:Finmer.Gameplay"
     mc:Ignorable="d"
     d:DesignWidth="1000" d:DesignHeight="640"
     d:DataContext="{d:DesignData Source=../Models/DesignData/SampleCharacterSheet.xaml}">
@@ -212,66 +213,44 @@
         </StackPanel>
 
         <!-- MIDDLE PANEL -->
-        <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Vertical">
-            <!-- Equipment -->
-            <TextBlock Text="Equipment" Style="{StaticResource TextBlockLarge}" />
-            <StackPanel Margin="10,16,10,24" Orientation="Horizontal">
-                <v:ItemBoxView
-                    Margin="0,0,12,0"
-                    SelectedChanged="EquipmentBox_SelectedChanged"
-                    DisplayedItem="{Binding Equipment[0]}" />
-                <v:ItemBoxView
-                    Margin="0,0,12,0"
-                    SelectedChanged="EquipmentBox_SelectedChanged"
-                    DisplayedItem="{Binding Equipment[1]}" />
+        <DockPanel Grid.Column="1" Grid.Row="0">
+            <StackPanel DockPanel.Dock="Top" Orientation="Vertical">
+                <!-- Equipment -->
+                <TextBlock Text="Equipment" Style="{StaticResource TextBlockLarge}" />
+                <StackPanel Margin="10,16,10,24" Orientation="Horizontal">
+                    <v:ItemBoxView
+                        Margin="0,0,12,0"
+                        SelectedChanged="EquipmentBox_SelectedChanged"
+                        DisplayedItem="{Binding Equipment[0]}" />
+                    <v:ItemBoxView
+                        Margin="0,0,12,0"
+                        SelectedChanged="EquipmentBox_SelectedChanged"
+                        DisplayedItem="{Binding Equipment[1]}" />
+                </StackPanel>
+
+                <!-- Inventory -->
+                <TextBlock Text="Backpack" Style="{StaticResource TextBlockLarge}" />
+                <Grid Margin="14">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <!-- Money -->
+                    <StackPanel Orientation="Horizontal" Grid.Column="0">
+                        <Image Source="/Finmer;component/Resources/UI/Money.png" Stretch="None" Margin="0,0,8,0" RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                        <TextBlock Style="{StaticResource TextBlockDefault}">
+                            <Run Text="{Binding Money, Mode=OneWay}" />
+                        </TextBlock>
+                    </StackPanel>
+                    <!-- Item count -->
+                    <StackPanel Orientation="Horizontal" Grid.Column="1">
+                        <Image Source="/Finmer;component/Resources/UI/StatInventory.png" Stretch="None" Margin="0,0,8,0" RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                        <TextBlock Style="{StaticResource TextBlockDefault}">
+                            <Run Text="{Binding Inventory.Count, Mode=OneWay}" /> item(s)
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
             </StackPanel>
-
-            <!-- Inventory -->
-            <TextBlock Text="Backpack" Style="{StaticResource TextBlockLarge}" />
-            <Grid Margin="14">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <!-- Money -->
-                <StackPanel Orientation="Horizontal" Grid.Column="0">
-                    <Image Source="/Finmer;component/Resources/UI/Money.png" Stretch="None" Margin="0,0,8,0" RenderOptions.BitmapScalingMode="NearestNeighbor" />
-                    <TextBlock Style="{StaticResource TextBlockDefault}">
-                        <Run Text="{Binding Money, Mode=OneWay}" />
-                    </TextBlock>
-                </StackPanel>
-                <!-- Item count -->
-                <StackPanel Orientation="Horizontal" Grid.Column="1">
-                    <Image Source="/Finmer;component/Resources/UI/StatInventory.png" Stretch="None" Margin="0,0,8,0" RenderOptions.BitmapScalingMode="NearestNeighbor" />
-                    <TextBlock Style="{StaticResource TextBlockDefault}">
-                        <Run Text="{Binding Inventory.Count, Mode=OneWay}" /> item(s)
-                    </TextBlock>
-                </StackPanel>
-            </Grid>
-
-            <!-- Inventory list -->
-            <v:ItemListView
-                ItemsSource="{Binding Inventory}" />
-
-            <!-- Item actions -->
-            <Grid Margin="4">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Button
-                    Grid.Column="0"
-                    Margin="3"
-                    Height="35"
-                    Content="Use"
-                    IsEnabled="False" />
-                <Button
-                    Grid.Column="1"
-                    Margin="3"
-                    Height="35"
-                    Content="Drop"
-                    IsEnabled="False" />
-            </Grid>
             <Popup x:Name="PopupDropConfirm" MaxWidth="200" StaysOpen="False">
                 <Border Style="{StaticResource PopupBorderStyle}">
                     <StackPanel>
@@ -281,7 +260,36 @@
                     </StackPanel>
                 </Border>
             </Popup>
-        </StackPanel>
+
+            <!-- Inventory list -->
+            <v:ItemListView ItemsSource="{Binding Inventory}">
+                <v:ItemListView.ItemOptionsTemplate>
+                    <ControlTemplate>
+                        <!-- Item action buttons -->
+                        <Grid
+                            d:DataContext="{d:DesignInstance gp:Item}"
+                            Margin="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Button
+                                Grid.Column="0"
+                                Margin="2"
+                                Height="35"
+                                Content="Use"
+                                IsEnabled="{Binding Asset.CanUseInField}" />
+                            <Button
+                                Grid.Column="1"
+                                Margin="2"
+                                Height="35"
+                                Content="Drop"
+                                IsEnabled="{Binding Asset.IsQuestItem}" />
+                        </Grid>
+                    </ControlTemplate>
+                </v:ItemListView.ItemOptionsTemplate>
+            </v:ItemListView>
+        </DockPanel>
 
         <!-- RIGHT PANEL -->
         <DockPanel Grid.Column="2" Grid.Row="0">

--- a/Finmer.Game/Views/CharSheetPage.xaml
+++ b/Finmer.Game/Views/CharSheetPage.xaml
@@ -217,11 +217,11 @@
                 <!-- Equipment -->
                 <TextBlock Text="Equipment" Style="{StaticResource TextBlockLarge}" />
                 <StackPanel Margin="10,16,10,24" Orientation="Horizontal">
-                    <v:ItemBoxView
+                    <v:ItemEquipmentBoxView
                         Margin="0,0,12,0"
                         SelectedChanged="EquipmentBox_SelectedChanged"
                         DisplayedItem="{Binding Equipment[0]}" />
-                    <v:ItemBoxView
+                    <v:ItemEquipmentBoxView
                         Margin="0,0,12,0"
                         SelectedChanged="EquipmentBox_SelectedChanged"
                         DisplayedItem="{Binding Equipment[1]}" />

--- a/Finmer.Game/Views/CharSheetPage.xaml
+++ b/Finmer.Game/Views/CharSheetPage.xaml
@@ -7,11 +7,15 @@
     xmlns:cv="clr-namespace:Finmer.Converters"
     xmlns:v="clr-namespace:Finmer.Views"
     xmlns:gp="clr-namespace:Finmer.Gameplay"
+    xmlns:vm="clr-namespace:Finmer.ViewModels"
     mc:Ignorable="d"
     d:DesignWidth="1000" d:DesignHeight="640"
     d:DataContext="{d:DesignData Source=../Models/DesignData/SampleCharacterSheet.xaml}">
     <UserControl.Resources>
         <cv:StringCapFirstConverter x:Key="StringCapFirstConverter" />
+        <cv:CharSheetItemUseConverter x:Key="CharSheetItemUseConverter" />
+        <cv:CharSheetItemDropConverter x:Key="CharSheetItemDropConverter" />
+        <cv:CharSheetUseLabelConverter x:Key="CharSheetUseLabelConverter" />
     </UserControl.Resources>
     <Grid
         HorizontalAlignment="Center"
@@ -262,7 +266,7 @@
             </Popup>
 
             <!-- Inventory list -->
-            <v:ItemListView ItemsSource="{Binding Inventory}">
+            <v:ItemListView ItemsSource="{Binding Inventory, Mode=OneWay}">
                 <v:ItemListView.ItemOptionsTemplate>
                     <ControlTemplate>
                         <!-- Item action buttons -->
@@ -273,18 +277,24 @@
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
+                            <!-- Use/Equip button -->
                             <Button
                                 Grid.Column="0"
                                 Margin="2"
                                 Height="35"
-                                Content="Use"
-                                IsEnabled="{Binding Asset.CanUseInField}" />
+                                Content="{Binding Converter={StaticResource CharSheetUseLabelConverter}}"
+                                Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.UseItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
+                                CommandParameter="{Binding}"
+                                IsEnabled="{Binding Converter={StaticResource CharSheetItemUseConverter}}" />
+                            <!-- Drop button -->
                             <Button
                                 Grid.Column="1"
                                 Margin="2"
                                 Height="35"
                                 Content="Drop"
-                                IsEnabled="{Binding Asset.IsQuestItem}" />
+                                Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.DropItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
+                                CommandParameter="{Binding}"
+                                IsEnabled="{Binding Converter={StaticResource CharSheetItemDropConverter}}" />
                         </Grid>
                     </ControlTemplate>
                 </v:ItemListView.ItemOptionsTemplate>

--- a/Finmer.Game/Views/CharSheetPage.xaml
+++ b/Finmer.Game/Views/CharSheetPage.xaml
@@ -6,16 +6,11 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:cv="clr-namespace:Finmer.Converters"
     xmlns:v="clr-namespace:Finmer.Views"
-    xmlns:gp="clr-namespace:Finmer.Gameplay"
-    xmlns:vm="clr-namespace:Finmer.ViewModels"
     mc:Ignorable="d"
     d:DesignWidth="1000" d:DesignHeight="640"
     d:DataContext="{d:DesignData Source=../Models/DesignData/SampleCharacterSheet.xaml}">
     <UserControl.Resources>
         <cv:StringCapFirstConverter x:Key="StringCapFirstConverter" />
-        <cv:CharSheetItemUseConverter x:Key="CharSheetItemUseConverter" />
-        <cv:CharSheetItemDropConverter x:Key="CharSheetItemDropConverter" />
-        <cv:CharSheetUseLabelConverter x:Key="CharSheetUseLabelConverter" />
     </UserControl.Resources>
     <Grid
         HorizontalAlignment="Center"
@@ -255,47 +250,12 @@
                     </StackPanel>
                 </Grid>
             </StackPanel>
-            <Popup x:Name="PopupDropConfirm" MaxWidth="200" StaysOpen="False">
-                <Border Style="{StaticResource PopupBorderStyle}">
-                    <StackPanel>
-                        <TextBlock Style="{StaticResource TextBlockDefault}" Margin="6,6,6,16" TextWrapping="Wrap" />
-                        <Button Height="35" Content="Drop" Foreground="OrangeRed" Margin="5,0,5,5" />
-                        <Button Height="35" Content="Never mind" Margin="5,0,5,5" />
-                    </StackPanel>
-                </Border>
-            </Popup>
 
             <!-- Inventory list -->
             <v:ItemListView ItemsSource="{Binding Inventory, Mode=OneWay}">
                 <v:ItemListView.ItemOptionsTemplate>
                     <ControlTemplate>
-                        <!-- Item action buttons -->
-                        <Grid
-                            d:DataContext="{d:DesignInstance gp:Item}"
-                            Margin="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <!-- Use/Equip button -->
-                            <Button
-                                Grid.Column="0"
-                                Margin="2"
-                                Height="35"
-                                Content="{Binding Converter={StaticResource CharSheetUseLabelConverter}}"
-                                Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.UseItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
-                                CommandParameter="{Binding}"
-                                IsEnabled="{Binding Converter={StaticResource CharSheetItemUseConverter}}" />
-                            <!-- Drop button -->
-                            <Button
-                                Grid.Column="1"
-                                Margin="2"
-                                Height="35"
-                                Content="Drop"
-                                Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.DropItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
-                                CommandParameter="{Binding}"
-                                IsEnabled="{Binding Converter={StaticResource CharSheetItemDropConverter}}" />
-                        </Grid>
+                        <v:CharSheetInventoryItemActions />
                     </ControlTemplate>
                 </v:ItemListView.ItemOptionsTemplate>
             </v:ItemListView>

--- a/Finmer.Game/Views/CharSheetPage.xaml
+++ b/Finmer.Game/Views/CharSheetPage.xaml
@@ -219,11 +219,11 @@
                 <StackPanel Margin="10,16,10,24" Orientation="Horizontal">
                     <v:ItemEquipmentBoxView
                         Margin="0,0,12,0"
-                        SelectedChanged="EquipmentBox_SelectedChanged"
+                        EquipmentIndex="0"
                         DisplayedItem="{Binding Equipment[0]}" />
                     <v:ItemEquipmentBoxView
                         Margin="0,0,12,0"
-                        SelectedChanged="EquipmentBox_SelectedChanged"
+                        EquipmentIndex="1"
                         DisplayedItem="{Binding Equipment[1]}" />
                 </StackPanel>
 

--- a/Finmer.Game/Views/CharSheetPage.xaml
+++ b/Finmer.Game/Views/CharSheetPage.xaml
@@ -8,11 +8,15 @@
     xmlns:v="clr-namespace:Finmer.Views"
     mc:Ignorable="d"
     d:DesignWidth="1000" d:DesignHeight="640"
-    d:DataContext="{d:DesignData Source=../Models/DesignData/SamplePlayer.xaml}">
+    d:DataContext="{d:DesignData Source=../Models/DesignData/SampleCharacterSheet.xaml}">
     <UserControl.Resources>
         <cv:StringCapFirstConverter x:Key="StringCapFirstConverter" />
     </UserControl.Resources>
-    <Grid HorizontalAlignment="Center" VerticalAlignment="Center" Width="800" Height="600">
+    <Grid
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Width="800"
+        Height="600">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
@@ -24,15 +28,28 @@
         </Grid.ColumnDefinitions>
 
         <!-- Back button -->
-        <Button Grid.Column="2" Grid.Row="1" Width="180" Height="40" HorizontalAlignment="Right" Content="Back" Click="BackButton_Click" />
+        <Button
+            Grid.Column="2"
+            Grid.Row="1"
+            Width="180"
+            Height="40"
+            HorizontalAlignment="Right"
+            Content="Close"
+            Click="BackButton_Click" />
 
-        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Vertical">
-            <!-- Character info -->
-            <TextBlock Text="{Binding Name, Mode=OneTime}" Style="{StaticResource TextBlockLargest}" />
-            <TextBlock Style="{StaticResource TextBlockLarge}">
-                <Run Text="{Binding Species, Mode=OneTime, Converter={StaticResource StringCapFirstConverter}}" />
-            </TextBlock>
+        <!-- LEFT PANEL -->
+        <StackPanel
+            Grid.Column="0"
+            Grid.Row="0"
+            Orientation="Vertical">
 
+            <!-- Basic info -->
+            <TextBlock
+                Text="{Binding Name, Mode=OneTime}"
+                Style="{StaticResource TextBlockLargest}" />
+            <TextBlock
+                Text="{Binding Species, Mode=OneTime, Converter={StaticResource StringCapFirstConverter}}"
+                Style="{StaticResource TextBlockLarge}" />
             <TextBlock Style="{StaticResource TextBlockLarge}">
                 Level
                 <Run Text="{Binding Level, Mode=OneTime}" />
@@ -52,21 +69,50 @@
                 </Grid.RowDefinitions>
 
                 <!-- Armor -->
-                <Image Grid.Column="0" Grid.Row="0" Source="/Finmer;component/Resources/UI/StatDefense.png" Stretch="None" HorizontalAlignment="Left" VerticalAlignment="Top" RenderOptions.BitmapScalingMode="NearestNeighbor" />
-                <TextBlock Grid.Column="1" Grid.Row="0" Margin="0,0,0,15" Style="{StaticResource TextBlockDefault}">
+                <Image
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Source="/Finmer;component/Resources/UI/StatDefense.png"
+                    Stretch="None"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                <TextBlock
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,0,15"
+                    Style="{StaticResource TextBlockDefault}">
                     ??? Armor
                 </TextBlock>
 
                 <!-- Offense -->
-                <Image Grid.Column="0" Grid.Row="1" Source="/Finmer;component/Resources/UI/StatOffense.png" Stretch="None" HorizontalAlignment="Left" VerticalAlignment="Top" RenderOptions.BitmapScalingMode="NearestNeighbor" />
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,0,15" Style="{StaticResource TextBlockDefault}">
+                <Image
+                    Grid.Column="0"
+                    Grid.Row="1"
+                    Source="/Finmer;component/Resources/UI/StatOffense.png"
+                    Stretch="None"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                <TextBlock
+                    Grid.Column="1"
+                    Grid.Row="1"
+                    Margin="0,0,0,15"
+                    Style="{StaticResource TextBlockDefault}">
                     Some Weapon
                     <LineBreak />
                     Damage: ???
                 </TextBlock>
 
                 <!-- Vore -->
-                <Image Grid.Column="0" Grid.Row="2" Source="/Finmer;component/Resources/UI/StatVore.png" Stretch="None" HorizontalAlignment="Left" VerticalAlignment="Top" RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                <Image
+                    Grid.Column="0"
+                    Grid.Row="2"
+                    Source="/Finmer;component/Resources/UI/StatVore.png"
+                    Stretch="None"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    RenderOptions.BitmapScalingMode="NearestNeighbor" />
                 <Grid Grid.Column="1" Grid.Row="2" Margin="0,0,0,15">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -77,25 +123,36 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Column="0" Grid.Row="0" Style="{StaticResource TextBlockDefault}">
-                        Some pred stat:<LineBreak />
-                        Some bonus:
+                        Example stat 1:<LineBreak />
+                        Example stat 2:
                     </TextBlock>
                     <TextBlock Grid.Column="1" Grid.Row="0" Style="{StaticResource TextBlockDefault}">
                         + 4<LineBreak />
                         + 1
                     </TextBlock>
-                    <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1"
+
+                    <!-- Prey list -->
+                    <TextBlock
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Grid.Row="1"
                         Style="{StaticResource TextBlockDefault}"
-                        DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type v:CharSheetPage}}}"
-                        Visibility="{Binding ShowDigestingPreyPanel, Mode=OneTime}">
+                        Visibility="{Binding PreyVisibility, Mode=OneTime}">
                         <Run Text="Currently digesting prey:" Foreground="{StaticResource DepressedBrush}" />
                         <LineBreak />
-                        <Run Text="{Binding DigestingPreyList, Mode=OneTime}" />
+                        <Run Text="{Binding PreyList, Mode=OneTime}" />
                     </TextBlock>
                 </Grid>
 
                 <!-- Abilities -->
-                <Image Grid.Column="0" Grid.Row="3" Source="/Finmer;component/Resources/UI/StatPrimary.png" Stretch="None" HorizontalAlignment="Left" VerticalAlignment="Top" RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                <Image
+                    Grid.Column="0"
+                    Grid.Row="3"
+                    Source="/Finmer;component/Resources/UI/StatPrimary.png"
+                    Stretch="None"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    RenderOptions.BitmapScalingMode="NearestNeighbor" />
                 <Grid Grid.Column="1" Grid.Row="3">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="3*" />
@@ -116,7 +173,7 @@
                     </TextBlock>
                     <TextBlock Grid.Column="2"
                         Style="{StaticResource TextBlockDefault}"
-                        Visibility="{Binding ShowIncreaseAbilityPanel, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type v:CharSheetPage}}}">
+                        Visibility="{Binding AbilityPointVisibility}">
                         <!-- Animated pulsing of this text block, to draw user's attention to unspent points -->
                         <TextBlock.Background>
                             <SolidColorBrush x:Name="AbilityUpgradePanelAnimatedBack" Color="{StaticResource ButtonHoverColorAlt}" Opacity="0" />
@@ -141,37 +198,32 @@
                                 </BeginStoryboard>
                             </EventTrigger>
                         </TextBlock.Triggers>
-                        <Hyperlink Command="{Binding IncreaseAbilityCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type v:CharSheetPage}}}" CommandParameter="0">+1</Hyperlink>
-                        <Span Foreground="{StaticResource DepressedBrush}">(<Run Text="{Binding AbilityPoints, Mode=OneWay}" /> left)</Span><LineBreak />
-                        <Hyperlink Command="{Binding IncreaseAbilityCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type v:CharSheetPage}}}" CommandParameter="1">+1</Hyperlink><LineBreak />
-                        <Hyperlink Command="{Binding IncreaseAbilityCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type v:CharSheetPage}}}" CommandParameter="2">+1</Hyperlink><LineBreak />
-                        <Hyperlink Command="{Binding IncreaseAbilityCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type v:CharSheetPage}}}" CommandParameter="3">+1</Hyperlink>
+                        <Hyperlink Command="{Binding IncreaseAbilityCommand}" CommandParameter="0">+1</Hyperlink>
+                        <Span Foreground="{StaticResource DepressedBrush}">(<Run Text="{Binding AbilityPoints, Mode=OneWay}" /> left)</Span>
+                        <LineBreak />
+                        <Hyperlink Command="{Binding IncreaseAbilityCommand}" CommandParameter="1">+1</Hyperlink>
+                        <LineBreak />
+                        <Hyperlink Command="{Binding IncreaseAbilityCommand}" CommandParameter="2">+1</Hyperlink>
+                        <LineBreak />
+                        <Hyperlink Command="{Binding IncreaseAbilityCommand}" CommandParameter="3">+1</Hyperlink>
                     </TextBlock>
                 </Grid>
             </Grid>
         </StackPanel>
 
+        <!-- MIDDLE PANEL -->
         <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Vertical">
             <!-- Equipment -->
             <TextBlock Text="Equipment" Style="{StaticResource TextBlockLarge}" />
             <StackPanel Margin="10,16,10,24" Orientation="Horizontal">
-                <StackPanel.Resources>
-                    <Style TargetType="v:ItemBoxView">
-                        <Setter Property="Margin" Value="0,0,10,0" />
-                        <Setter Property="ToolTipService.ShowDuration" Value="12000" />
-                        <Setter Property="ToolTip">
-                            <Setter.Value>
-                                <v:ItemTooltipView />
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </StackPanel.Resources>
-                <v:ItemBoxView DataContext="{Binding Equipment[0]}" MouseDown="ItemBoxView_MouseDown" Tag="0" />
-                <v:ItemBoxView DataContext="{Binding Equipment[1]}" MouseDown="ItemBoxView_MouseDown" Tag="1" />
-                <!-- Shield and Charms slots, which we do not use for now
-                <v:ItemBoxView DataContext="{Binding Equipment[2]}" MouseDown="ItemBoxView_MouseDown" Tag="2" />
-                <v:ItemBoxView DataContext="{Binding Equipment[3]}" MouseDown="ItemBoxView_MouseDown" Tag="3" />
-                <v:ItemBoxView DataContext="{Binding Equipment[4]}" MouseDown="ItemBoxView_MouseDown" Tag="4" /> -->
+                <v:ItemBoxView
+                    Margin="0,0,12,0"
+                    SelectedChanged="EquipmentBox_SelectedChanged"
+                    DisplayedItem="{Binding Equipment[0]}" />
+                <v:ItemBoxView
+                    Margin="0,0,12,0"
+                    SelectedChanged="EquipmentBox_SelectedChanged"
+                    DisplayedItem="{Binding Equipment[1]}" />
             </StackPanel>
 
             <!-- Inventory -->
@@ -181,12 +233,14 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
+                <!-- Money -->
                 <StackPanel Orientation="Horizontal" Grid.Column="0">
                     <Image Source="/Finmer;component/Resources/UI/Money.png" Stretch="None" Margin="0,0,8,0" RenderOptions.BitmapScalingMode="NearestNeighbor" />
                     <TextBlock Style="{StaticResource TextBlockDefault}">
                         <Run Text="{Binding Money, Mode=OneWay}" />
                     </TextBlock>
                 </StackPanel>
+                <!-- Item count -->
                 <StackPanel Orientation="Horizontal" Grid.Column="1">
                     <Image Source="/Finmer;component/Resources/UI/StatInventory.png" Stretch="None" Margin="0,0,8,0" RenderOptions.BitmapScalingMode="NearestNeighbor" />
                     <TextBlock Style="{StaticResource TextBlockDefault}">
@@ -194,29 +248,42 @@
                     </TextBlock>
                 </StackPanel>
             </Grid>
-            <v:ItemListView x:Name="ItemList" MaxHeight="244" ItemsSource="{Binding Inventory}" SelectionChanged="ItemListView_SelectionChanged" />
+
+            <!-- Inventory list -->
+            <v:ItemListView
+                ItemsSource="{Binding Inventory}" />
 
             <!-- Item actions -->
-            <StackPanel Margin="4,16,4,4" Orientation="Horizontal">
-                <Button Name="ItemUseButton" Margin="4" Height="35" Width="120" Content="Use" Click="ItemUseButton_Click" IsEnabled="False" />
-                <Button Name="ItemDropButton" Height="35" Width="120" Content="Drop" Click="ItemDropButton_Click" IsEnabled="False" />
-            </StackPanel>
-            <Popup x:Name="PopupSimple" MaxWidth="200" StaysOpen="False">
-                <Border Style="{StaticResource PopupBorderStyle}">
-                    <TextBlock x:Name="PopupSimpleText" Style="{StaticResource TextBlockDefault}" Margin="4" Text="aaaaa" TextWrapping="Wrap" />
-                </Border>
-            </Popup>
+            <Grid Margin="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Button
+                    Grid.Column="0"
+                    Margin="3"
+                    Height="35"
+                    Content="Use"
+                    IsEnabled="False" />
+                <Button
+                    Grid.Column="1"
+                    Margin="3"
+                    Height="35"
+                    Content="Drop"
+                    IsEnabled="False" />
+            </Grid>
             <Popup x:Name="PopupDropConfirm" MaxWidth="200" StaysOpen="False">
                 <Border Style="{StaticResource PopupBorderStyle}">
                     <StackPanel>
-                        <TextBlock x:Name="PopupDropText" Style="{StaticResource TextBlockDefault}" Margin="6,6,6,16" TextWrapping="Wrap" />
-                        <Button x:Name="DropConfirmButton" Height="35" Content="Drop" Foreground="OrangeRed" Margin="5,0,5,5" Click="DropConfirmButton_Click" />
-                        <Button x:Name="DropCancelButton" Height="35" Content="Never mind" Margin="5,0,5,5" Click="DropCancelButton_Click" />
+                        <TextBlock Style="{StaticResource TextBlockDefault}" Margin="6,6,6,16" TextWrapping="Wrap" />
+                        <Button Height="35" Content="Drop" Foreground="OrangeRed" Margin="5,0,5,5" />
+                        <Button Height="35" Content="Never mind" Margin="5,0,5,5" />
                     </StackPanel>
                 </Border>
             </Popup>
         </StackPanel>
 
+        <!-- RIGHT PANEL -->
         <DockPanel Grid.Column="2" Grid.Row="0">
             <!-- Quest Journal -->
             <TextBlock
@@ -224,7 +291,7 @@
                 Text="Journal"
                 Style="{StaticResource TextBlockLarge}" />
             <v:JournalListView
-                x:Name="JournalList"
+                DataContext="{Binding JournalViewModel}"
                 Margin="10,16,10,24" />
         </DockPanel>
     </Grid>

--- a/Finmer.Game/Views/CharSheetPage.xaml.cs
+++ b/Finmer.Game/Views/CharSheetPage.xaml.cs
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System.Diagnostics;
 using System.Windows;
 using Finmer.Gameplay;
 using Finmer.Utility;
@@ -21,31 +20,18 @@ namespace Finmer.Views
     public partial class CharSheetPage
     {
 
-        private readonly CharacterSheetViewModel m_ViewModel;
-
         public CharSheetPage()
         {
             InitializeComponent();
 
             // Populate the main view
             var player = GameController.Session.Player;
-            m_ViewModel = new CharacterSheetViewModel(player);
-            DataContext = m_ViewModel;
+            DataContext = new CharacterSheetViewModel(player);
         }
 
         private void BackButton_Click(object sender, RoutedEventArgs e)
         {
             GameController.Window.Navigate(new MainPage(), ENavigatorAnimation.SlideRight);
-        }
-
-        private void EquipmentBox_SelectedChanged(object sender, RoutedEventArgs e)
-        {
-            ItemEquipmentBoxView box = sender as ItemEquipmentBoxView;
-            if (box == null || !box.IsSelected)
-                return;
-
-            // Update which box is currently selected
-            Debug.WriteLine(box.DisplayedItem?.Asset.ObjectName ?? "Nothing");
         }
 
     }

--- a/Finmer.Game/Views/CharSheetPage.xaml.cs
+++ b/Finmer.Game/Views/CharSheetPage.xaml.cs
@@ -6,19 +6,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using Finmer.Core.Assets;
 using Finmer.Gameplay;
 using Finmer.Utility;
 using Finmer.ViewModels;
-using JetBrains.Annotations;
 
 namespace Finmer.Views
 {
@@ -26,14 +18,10 @@ namespace Finmer.Views
     /// <summary>
     /// Interaction logic for CharSheetPage.xaml
     /// </summary>
-    public partial class CharSheetPage : INotifyPropertyChanged
+    public partial class CharSheetPage
     {
 
-        private ItemBoxView m_EquipSelBox;
-
-        private int m_EquipSelIndex = -1;
-
-        private ICommand m_IncreaseAbilityCmd;
+        private readonly CharacterSheetViewModel m_ViewModel;
 
         public CharSheetPage()
         {
@@ -41,167 +29,23 @@ namespace Finmer.Views
 
             // Populate the main view
             var player = GameController.Session.Player;
-            DataContext = player.GetOrCreateViewModel();
-
-            // Populate the journal list
-            JournalList.DataContext = new JournalViewModel(player.Journal);
+            m_ViewModel = new CharacterSheetViewModel(player);
+            DataContext = m_ViewModel;
         }
-
-        public ICommand IncreaseAbilityCommand => m_IncreaseAbilityCmd ?? (m_IncreaseAbilityCmd = new RelayCommand(IncreaseAbilityLink_Click));
-
-        public Visibility ShowIncreaseAbilityPanel => GameController.Session.Player.AbilityPoints > 0 ? Visibility.Visible : Visibility.Hidden;
-
-        public Visibility ShowDigestingPreyPanel => GameController.Session.Player.StomachFullness > 0f ? Visibility.Visible : Visibility.Collapsed;
-        public string DigestingPreyList => String.Join(", ", GameController.Session.Player.Stomach.Select(prey => prey.Name));
-
-        public event PropertyChangedEventHandler PropertyChanged;
 
         private void BackButton_Click(object sender, RoutedEventArgs e)
         {
             GameController.Window.Navigate(new MainPage(), ENavigatorAnimation.SlideRight);
         }
 
-        private void ItemUseButton_Click(object sender, RoutedEventArgs e)
+        private void EquipmentBox_SelectedChanged(object sender, RoutedEventArgs e)
         {
-            Debug.Assert(ItemList.SelectedIndex >= 0 || m_EquipSelIndex >= 0);
-
-            // deselect slot and update sheet
-            Deselect();
-        }
-
-        private void ItemDropButton_Click(object sender, RoutedEventArgs e)
-        {
-            string name = GameController.Session.Player.Inventory[ItemList.SelectedIndex].Name;
-            PopupDropText.Text = $"Are you sure you want to get rid of {name}?";
-            DropConfirmButton.Content = "Drop " + name;
-            PopupDropConfirm.PlacementTarget = ItemDropButton;
-            PopupDropConfirm.IsOpen = true;
-        }
-
-        private void Deselect()
-        {
-            if (m_EquipSelIndex >= 0)
-                m_EquipSelBox.IsEnabled = true;
-            ItemList.SelectedIndex = -1;
-            m_EquipSelIndex = -1;
-            CheckItemButtons();
-
-            // update listings
-            ItemList.Items.Refresh();
-        }
-
-        private void CheckItemButtons()
-        {
-            // determine which item is selected
-            Item item = null;
-            if (ItemList.SelectedIndex >= 0)
-                item = GameController.Session.Player.Inventory[ItemList.SelectedIndex];
-            else if (m_EquipSelIndex >= 0)
-                item = GameController.Session.Player.Equipment[m_EquipSelIndex];
-
-            if (item == null)
-            {
-                ItemUseButton.IsEnabled = false;
-                ItemDropButton.IsEnabled = false;
+            ItemBoxView box = sender as ItemBoxView;
+            if (box == null || !box.IsSelected)
                 return;
-            }
 
-            // can only drop inventory non-quest items
-            ItemDropButton.IsEnabled = ItemList.SelectedIndex >= 0 && !item.Asset.IsQuestItem;
-
-            // set up the Use button
-            switch (item.Asset.ItemType)
-            {
-                case AssetItem.EItemType.Armor:
-                case AssetItem.EItemType.Weapon:
-                    ItemUseButton.IsEnabled = true;
-                    ItemUseButton.Content = m_EquipSelIndex >= 0 ? "Unequip" : "Equip";
-                    break;
-
-                case AssetItem.EItemType.Usable:
-                    ItemUseButton.IsEnabled = item.Asset.CanUseInField;
-                    ItemUseButton.Content = item.Asset.CanUseInField ? "Use" : "Can't Use";
-                    break;
-
-                default:
-                    ItemUseButton.IsEnabled = false;
-                    ItemUseButton.Content = "Can't Use";
-                    break;
-            }
-        }
-
-        private void ItemListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (ItemList.SelectedIndex >= 0 && m_EquipSelIndex >= 0)
-            {
-                m_EquipSelBox.IsEnabled = true;
-                m_EquipSelIndex = -1;
-            }
-
-            CheckItemButtons();
-        }
-
-        private void ItemBoxView_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            // get slot index from tag
-            int index = int.Parse((string)((ItemBoxView)sender).Tag);
-            // cannot select empty equipment slots
-            if (GameController.Session.Player.Equipment[index] == null)
-                return;
-            // deselect previous box
-            if (m_EquipSelIndex >= 0)
-                m_EquipSelBox.IsEnabled = true;
-            // make the equip box selected
-            m_EquipSelIndex = index;
-            m_EquipSelBox = (ItemBoxView)sender;
-            m_EquipSelBox.IsEnabled = false;
-            ItemList.SelectedIndex = -1;
-            CheckItemButtons();
-        }
-
-        private void DropCancelButton_Click(object sender, RoutedEventArgs e)
-        {
-            PopupDropConfirm.IsOpen = false;
-        }
-
-        private void DropConfirmButton_Click(object sender, RoutedEventArgs e)
-        {
-            PopupDropConfirm.IsOpen = false;
-            GameController.Session.Player.Inventory.RemoveAt(ItemList.SelectedIndex);
-            Deselect();
-        }
-
-        private void IncreaseAbilityLink_Click(object args)
-        {
-            Player plr = GameController.Session.Player;
-            int stat_idx = Int32.Parse((string)args);
-            if (plr.AbilityPoints < 1) return;
-
-            plr.AbilityPoints--;
-
-            switch (stat_idx)
-            {
-                case 0:
-                    plr.Strength++;
-                    break;
-                case 1:
-                    plr.Agility++;
-                    break;
-                case 2:
-                    plr.Body++;
-                    break;
-                case 3:
-                    plr.Wits++;
-                    break;
-            }
-
-            OnBindPropertyChanged(nameof(ShowIncreaseAbilityPanel));
-        }
-
-        [NotifyPropertyChangedInvocator]
-        private void OnBindPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            // Update which box is currently selected
+            Debug.WriteLine(box.DisplayedItem?.Asset.ObjectName ?? "Nothing");
         }
 
     }

--- a/Finmer.Game/Views/CharSheetPage.xaml.cs
+++ b/Finmer.Game/Views/CharSheetPage.xaml.cs
@@ -40,7 +40,7 @@ namespace Finmer.Views
 
         private void EquipmentBox_SelectedChanged(object sender, RoutedEventArgs e)
         {
-            ItemBoxView box = sender as ItemBoxView;
+            ItemEquipmentBoxView box = sender as ItemEquipmentBoxView;
             if (box == null || !box.IsSelected)
                 return;
 

--- a/Finmer.Game/Views/ItemBoxView.xaml
+++ b/Finmer.Game/Views/ItemBoxView.xaml
@@ -5,29 +5,54 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:v="clr-namespace:Finmer.Views"
-    x:Name="ItemBoxWrapper"
     mc:Ignorable="d"
-    MinWidth="36" MaxWidth="36"
-    MinHeight="36" MaxHeight="36">
-    <UserControl.Resources>
-        <Style x:Key="ItemBoxBorderStyle" TargetType="{x:Type Border}">
-            <Setter Property="BorderBrush" Value="{StaticResource BrightBackgroundBrush}" />
-            <Setter Property="BorderThickness" Value="2" />
-            <Setter Property="Background" Value="{StaticResource DarkBackgroundBrush}" />
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <!-- Misusing IsEnabled to set state flag... I don't know how to bind triggers
-                         to custom dependency props higher up in the visual tree, so yeah. -->
-                    <Setter Property="Background" Value="{StaticResource BrightBackgroundBrush}" />
-                    <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-    </UserControl.Resources>
-    <Border Style="{StaticResource ItemBoxBorderStyle}">
-        <v:ItemIconView HorizontalAlignment="Center" VerticalAlignment="Center" />
+    MinWidth="36"
+    MaxWidth="36"
+    MinHeight="36"
+    MaxHeight="36">
+    <Border
+        d:DataContext="{d:DesignInstance v:ItemBoxView}"
+        DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=v:ItemBoxView}}"
+        MouseLeftButtonDown="OnClick"
+        ToolTipService.ShowDuration="12000">
+
+        <!-- Detailed item tooltip -->
+        <Border.ToolTip>
+            <!-- The tooltip lives in its own element tree, and needs to be explicitly bound to the ItemBoxView -->
+            <ToolTip
+                DataContext="{Binding Path=PlacementTarget.(FrameworkElement.DataContext).(v:ItemBoxView.DisplayedItem), RelativeSource={RelativeSource Self}}">
+                <v:ItemTooltipView />
+            </ToolTip>
+        </Border.ToolTip>
+
+        <!-- Border changes color depending on selection status -->
+        <Border.Style>
+            <Style TargetType="{x:Type Border}">
+                <Setter Property="BorderBrush" Value="{StaticResource BrightBackgroundBrush}" />
+                <Setter Property="BorderThickness" Value="2" />
+                <Setter Property="Background" Value="{StaticResource DarkBackgroundBrush}" />
+                <Style.Triggers>
+                    <!-- Highlight border when hovering -->
+                    <DataTrigger Binding="{Binding IsMouseOver}" Value="True">
+                        <DataTrigger.Setters>
+                            <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
+                        </DataTrigger.Setters>
+                    </DataTrigger>
+                    <!-- Bright background when selected -->
+                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                        <DataTrigger.Setters>
+                            <Setter Property="Background" Value="{StaticResource BrightBackgroundBrush}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
+                        </DataTrigger.Setters>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Border.Style>
+
+        <!-- Item icon centered in the box -->
+        <v:ItemIconView
+            DataContext="{Binding DisplayedItem}"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center" />
     </Border>
 </UserControl>

--- a/Finmer.Game/Views/ItemBoxView.xaml.cs
+++ b/Finmer.Game/Views/ItemBoxView.xaml.cs
@@ -6,7 +6,10 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using System;
 using System.Windows;
+using System.Windows.Input;
+using Finmer.Gameplay;
 
 namespace Finmer.Views
 {
@@ -17,18 +20,84 @@ namespace Finmer.Views
     public partial class ItemBoxView
     {
 
-        public static readonly DependencyProperty BoxSelectedProperty = DependencyProperty.Register(
-            "BoxSelected", typeof(bool), typeof(ItemBoxView), new PropertyMetadata(false));
+        /// <summary>
+        /// Currently selected item box.
+        /// </summary>
+        /// <remarks>
+        /// Note that this is a static because that's a much simpler solution than implementing some kind of overarching viewmodel for
+        /// simulating radio buttons etc. Also, it's a weak reference to ensure that the field does not keep closed UI trees alive.
+        /// </remarks>
+        private static readonly WeakReference<ItemBoxView> s_Selected = new WeakReference<ItemBoxView>(null);
+
+        /// <summary>
+        /// Dependency property for DisplayedItem.
+        /// </summary>
+        public static readonly DependencyProperty DisplayedItemProperty = DependencyProperty.Register(
+            "DisplayedItem", typeof(Item), typeof(ItemBoxView), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Dependency property for IsSelected.
+        /// </summary>
+        public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register(
+            "IsSelected", typeof(bool), typeof(ItemBoxView), new PropertyMetadata(false));
+
+        /// <summary>
+        /// Routed event for SelectedChanged.
+        /// </summary>
+        public static readonly RoutedEvent SelectedChangedEvent = EventManager.RegisterRoutedEvent(
+            "SelectedChanged", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(ItemBoxView));
+
+        /// <summary>
+        /// Indicates whether the user has activated this UI element.
+        /// </summary>
+        public Item DisplayedItem
+        {
+            get => (Item)GetValue(DisplayedItemProperty);
+            set => SetValue(DisplayedItemProperty, value);
+        }
+
+        /// <summary>
+        /// Indicates whether the user has activated this UI element.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => (bool)GetValue(IsSelectedProperty);
+            set => SetValue(IsSelectedProperty, value);
+        }
 
         public ItemBoxView()
         {
             InitializeComponent();
         }
 
-        public bool BoxSelected
+        /// <summary>
+        /// Fired when the selection status of this UI element changes.
+        /// </summary>
+        public event RoutedEventHandler SelectedChanged
         {
-            get => (bool)GetValue(BoxSelectedProperty);
-            set => SetValue(BoxSelectedProperty, value);
+            add => AddHandler(SelectedChangedEvent, value);
+            remove => RemoveHandler(SelectedChangedEvent, value);
+        }
+
+        private void OnClick(object sender, MouseButtonEventArgs e)
+        {
+            // Deselect the previous selected box, if any.
+            if (s_Selected.TryGetTarget(out ItemBoxView previous))
+            {
+                previous.IsSelected = false;
+                previous.RaiseEvent(new RoutedEventArgs(SelectedChangedEvent, previous));
+            }
+
+            // Can only select a box if it has an item in it
+            if (DisplayedItem == null)
+                return;
+
+            // Assign the new box
+            s_Selected.SetTarget(this);
+            IsSelected = true;
+
+            // Trigger event
+            RaiseEvent(new RoutedEventArgs(SelectedChangedEvent, this));
         }
 
     }

--- a/Finmer.Game/Views/ItemEquipmentBoxView.xaml
+++ b/Finmer.Game/Views/ItemEquipmentBoxView.xaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    x:Class="Finmer.Views.ItemBoxView"
+    x:Class="Finmer.Views.ItemEquipmentBoxView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -11,8 +11,8 @@
     MinHeight="36"
     MaxHeight="36">
     <Border
-        d:DataContext="{d:DesignInstance v:ItemBoxView}"
-        DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=v:ItemBoxView}}"
+        d:DataContext="{d:DesignInstance v:ItemEquipmentBoxView}"
+        DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=v:ItemEquipmentBoxView}}"
         MouseLeftButtonDown="OnClick"
         ToolTipService.ShowDuration="12000">
 
@@ -20,7 +20,7 @@
         <Border.ToolTip>
             <!-- The tooltip lives in its own element tree, and needs to be explicitly bound to the ItemBoxView -->
             <ToolTip
-                DataContext="{Binding Path=PlacementTarget.(FrameworkElement.DataContext).(v:ItemBoxView.DisplayedItem), RelativeSource={RelativeSource Self}}">
+                DataContext="{Binding Path=PlacementTarget.(FrameworkElement.DataContext).(v:ItemEquipmentBoxView.DisplayedItem), RelativeSource={RelativeSource Self}}">
                 <v:ItemTooltipView />
             </ToolTip>
         </Border.ToolTip>

--- a/Finmer.Game/Views/ItemEquipmentBoxView.xaml
+++ b/Finmer.Game/Views/ItemEquipmentBoxView.xaml
@@ -5,54 +5,87 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:v="clr-namespace:Finmer.Views"
+    xmlns:vm="clr-namespace:Finmer.ViewModels"
     mc:Ignorable="d"
     MinWidth="36"
     MaxWidth="36"
     MinHeight="36"
     MaxHeight="36">
-    <Border
-        d:DataContext="{d:DesignInstance v:ItemEquipmentBoxView}"
-        DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=v:ItemEquipmentBoxView}}"
-        MouseLeftButtonDown="OnClick"
-        ToolTipService.ShowDuration="12000">
+    <Grid>
+        <Button Click="OpenActionsButton_Click">
+            <Button.Template>
+                <ControlTemplate TargetType="Button">
+                    <Border>
+                        <!-- Border changes color depending on selection status -->
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="BorderBrush" Value="{StaticResource BrightBackgroundBrush}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                                <Setter Property="Background" Value="{StaticResource DarkBackgroundBrush}" />
+                                <Style.Triggers>
+                                    <!-- Highlight border when hovering -->
+                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource FindAncestor, AncestorType=Button}}" Value="True">
+                                        <DataTrigger.Setters>
+                                            <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
+                                        </DataTrigger.Setters>
+                                    </DataTrigger>
+                                    <!-- Bright background when selected -->
+                                    <DataTrigger Binding="{Binding IsOpen, ElementName=EquipmentActionsPopup}" Value="True">
+                                        <DataTrigger.Setters>
+                                            <Setter Property="Background" Value="{StaticResource BrightBackgroundBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
+                                        </DataTrigger.Setters>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <!-- Button contents -->
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Button.Template>
 
-        <!-- Detailed item tooltip -->
-        <Border.ToolTip>
-            <!-- The tooltip lives in its own element tree, and needs to be explicitly bound to the ItemBoxView -->
-            <ToolTip
-                DataContext="{Binding Path=PlacementTarget.(FrameworkElement.DataContext).(v:ItemEquipmentBoxView.DisplayedItem), RelativeSource={RelativeSource Self}}">
-                <v:ItemTooltipView />
-            </ToolTip>
-        </Border.ToolTip>
+            <!-- Item display -->
+            <Grid
+                ToolTipService.ShowDuration="12000"
+                d:DataContext="{d:DesignInstance v:ItemEquipmentBoxView}"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=v:ItemEquipmentBoxView}}">
 
-        <!-- Border changes color depending on selection status -->
-        <Border.Style>
-            <Style TargetType="{x:Type Border}">
-                <Setter Property="BorderBrush" Value="{StaticResource BrightBackgroundBrush}" />
-                <Setter Property="BorderThickness" Value="2" />
-                <Setter Property="Background" Value="{StaticResource DarkBackgroundBrush}" />
-                <Style.Triggers>
-                    <!-- Highlight border when hovering -->
-                    <DataTrigger Binding="{Binding IsMouseOver}" Value="True">
-                        <DataTrigger.Setters>
-                            <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-                        </DataTrigger.Setters>
-                    </DataTrigger>
-                    <!-- Bright background when selected -->
-                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                        <DataTrigger.Setters>
-                            <Setter Property="Background" Value="{StaticResource BrightBackgroundBrush}" />
-                            <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-                        </DataTrigger.Setters>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-        </Border.Style>
+                <!-- Detailed item tooltip -->
+                <Grid.ToolTip>
+                    <!-- The tooltip lives in its own element tree, and needs to be explicitly bound to the ItemBoxView -->
+                    <ToolTip
+                        DataContext="{Binding Path=PlacementTarget.(FrameworkElement.DataContext).(v:ItemEquipmentBoxView.DisplayedItem), RelativeSource={RelativeSource Self}}">
+                        <v:ItemTooltipView />
+                    </ToolTip>
+                </Grid.ToolTip>
 
-        <!-- Item icon centered in the box -->
-        <v:ItemIconView
-            DataContext="{Binding DisplayedItem}"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center" />
-    </Border>
+                <!-- Item icon centered in the box -->
+                <v:ItemIconView
+                    DataContext="{Binding DisplayedItem}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center" />
+            </Grid>
+        </Button>
+
+        <!-- Equipment actions -->
+        <Popup
+            x:Name="EquipmentActionsPopup"
+            Width="100"
+            StaysOpen="False">
+            <Border Style="{StaticResource PopupBorderStyle}">
+                <StackPanel>
+                    <Button
+                        Margin="4"
+                        Height="32"
+                        Content="Unequip"
+                        Click="UnequipButton_Click"
+                        Command="{Binding Path=DataContext.(vm:CharacterSheetViewModel.UnequipItemCommand), RelativeSource={RelativeSource FindAncestor, AncestorType=v:CharSheetPage}}"
+                        CommandParameter="{Binding EquipmentIndex, RelativeSource={RelativeSource FindAncestor, AncestorType=v:ItemEquipmentBoxView}}" />
+                </StackPanel>
+            </Border>
+        </Popup>
+    </Grid>
 </UserControl>

--- a/Finmer.Game/Views/ItemEquipmentBoxView.xaml.cs
+++ b/Finmer.Game/Views/ItemEquipmentBoxView.xaml.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
 using Finmer.Gameplay;
@@ -21,31 +22,16 @@ namespace Finmer.Views
     {
 
         /// <summary>
-        /// Currently selected item box.
-        /// </summary>
-        /// <remarks>
-        /// Note that this is a static because that's a much simpler solution than implementing some kind of overarching viewmodel for
-        /// simulating radio buttons etc. Also, it's a weak reference to ensure that the field does not keep closed UI trees alive.
-        /// </remarks>
-        private static readonly WeakReference<ItemEquipmentBoxView> s_Selected = new WeakReference<ItemEquipmentBoxView>(null);
-
-        /// <summary>
         /// Dependency property for DisplayedItem.
         /// </summary>
         public static readonly DependencyProperty DisplayedItemProperty = DependencyProperty.Register(
             "DisplayedItem", typeof(Item), typeof(ItemEquipmentBoxView), new PropertyMetadata(null));
 
         /// <summary>
-        /// Dependency property for IsSelected.
+        /// Dependency property for EquipmentIndex.
         /// </summary>
-        public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register(
-            "IsSelected", typeof(bool), typeof(ItemEquipmentBoxView), new PropertyMetadata(false));
-
-        /// <summary>
-        /// Routed event for SelectedChanged.
-        /// </summary>
-        public static readonly RoutedEvent SelectedChangedEvent = EventManager.RegisterRoutedEvent(
-            "SelectedChanged", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(ItemEquipmentBoxView));
+        public static readonly DependencyProperty EquipmentIndexProperty = DependencyProperty.Register(
+            "EquipmentIndex", typeof(int), typeof(ItemEquipmentBoxView), new PropertyMetadata(0));
 
         /// <summary>
         /// Indicates whether the user has activated this UI element.
@@ -59,10 +45,10 @@ namespace Finmer.Views
         /// <summary>
         /// Indicates whether the user has activated this UI element.
         /// </summary>
-        public bool IsSelected
+        public int EquipmentIndex
         {
-            get => (bool)GetValue(IsSelectedProperty);
-            set => SetValue(IsSelectedProperty, value);
+            get => (int)GetValue(EquipmentIndexProperty);
+            set => SetValue(EquipmentIndexProperty, value);
         }
 
         public ItemEquipmentBoxView()
@@ -70,34 +56,17 @@ namespace Finmer.Views
             InitializeComponent();
         }
 
-        /// <summary>
-        /// Fired when the selection status of this UI element changes.
-        /// </summary>
-        public event RoutedEventHandler SelectedChanged
+        private void OpenActionsButton_Click(object sender, RoutedEventArgs e)
         {
-            add => AddHandler(SelectedChangedEvent, value);
-            remove => RemoveHandler(SelectedChangedEvent, value);
+            // Open the actions popup if there is actually an item in this box
+            if (DisplayedItem != null)
+                EquipmentActionsPopup.IsOpen = true;
         }
 
-        private void OnClick(object sender, MouseButtonEventArgs e)
+        private void UnequipButton_Click(object sender, RoutedEventArgs e)
         {
-            // Deselect the previous selected box, if any.
-            if (s_Selected.TryGetTarget(out ItemEquipmentBoxView previous))
-            {
-                previous.IsSelected = false;
-                previous.RaiseEvent(new RoutedEventArgs(SelectedChangedEvent, previous));
-            }
-
-            // Can only select a box if it has an item in it
-            if (DisplayedItem == null)
-                return;
-
-            // Assign the new box
-            s_Selected.SetTarget(this);
-            IsSelected = true;
-
-            // Trigger event
-            RaiseEvent(new RoutedEventArgs(SelectedChangedEvent, this));
+            // Ensure the popup closes
+            EquipmentActionsPopup.IsOpen = false;
         }
 
     }

--- a/Finmer.Game/Views/ItemEquipmentBoxView.xaml.cs
+++ b/Finmer.Game/Views/ItemEquipmentBoxView.xaml.cs
@@ -17,7 +17,7 @@ namespace Finmer.Views
     /// <summary>
     /// Interaction logic for ItemBoxView.xaml
     /// </summary>
-    public partial class ItemBoxView
+    public partial class ItemEquipmentBoxView
     {
 
         /// <summary>
@@ -27,25 +27,25 @@ namespace Finmer.Views
         /// Note that this is a static because that's a much simpler solution than implementing some kind of overarching viewmodel for
         /// simulating radio buttons etc. Also, it's a weak reference to ensure that the field does not keep closed UI trees alive.
         /// </remarks>
-        private static readonly WeakReference<ItemBoxView> s_Selected = new WeakReference<ItemBoxView>(null);
+        private static readonly WeakReference<ItemEquipmentBoxView> s_Selected = new WeakReference<ItemEquipmentBoxView>(null);
 
         /// <summary>
         /// Dependency property for DisplayedItem.
         /// </summary>
         public static readonly DependencyProperty DisplayedItemProperty = DependencyProperty.Register(
-            "DisplayedItem", typeof(Item), typeof(ItemBoxView), new PropertyMetadata(null));
+            "DisplayedItem", typeof(Item), typeof(ItemEquipmentBoxView), new PropertyMetadata(null));
 
         /// <summary>
         /// Dependency property for IsSelected.
         /// </summary>
         public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register(
-            "IsSelected", typeof(bool), typeof(ItemBoxView), new PropertyMetadata(false));
+            "IsSelected", typeof(bool), typeof(ItemEquipmentBoxView), new PropertyMetadata(false));
 
         /// <summary>
         /// Routed event for SelectedChanged.
         /// </summary>
         public static readonly RoutedEvent SelectedChangedEvent = EventManager.RegisterRoutedEvent(
-            "SelectedChanged", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(ItemBoxView));
+            "SelectedChanged", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(ItemEquipmentBoxView));
 
         /// <summary>
         /// Indicates whether the user has activated this UI element.
@@ -65,7 +65,7 @@ namespace Finmer.Views
             set => SetValue(IsSelectedProperty, value);
         }
 
-        public ItemBoxView()
+        public ItemEquipmentBoxView()
         {
             InitializeComponent();
         }
@@ -82,7 +82,7 @@ namespace Finmer.Views
         private void OnClick(object sender, MouseButtonEventArgs e)
         {
             // Deselect the previous selected box, if any.
-            if (s_Selected.TryGetTarget(out ItemBoxView previous))
+            if (s_Selected.TryGetTarget(out ItemEquipmentBoxView previous))
             {
                 previous.IsSelected = false;
                 previous.RaiseEvent(new RoutedEventArgs(SelectedChangedEvent, previous));

--- a/Finmer.Game/Views/ItemIconView.xaml
+++ b/Finmer.Game/Views/ItemIconView.xaml
@@ -9,5 +9,9 @@
     MinWidth="32" MaxWidth="32"
     MinHeight="32" MaxHeight="32"
     d:DataContext="{d:DesignInstance gp:Item}">
-    <Image HorizontalAlignment="Center" VerticalAlignment="Center" Source="{Binding Image}" RenderOptions.BitmapScalingMode="NearestNeighbor" />
+    <Image
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Source="{Binding Image}"
+        RenderOptions.BitmapScalingMode="NearestNeighbor" />
 </UserControl>

--- a/Finmer.Game/Views/ItemListView.xaml
+++ b/Finmer.Game/Views/ItemListView.xaml
@@ -8,35 +8,52 @@
     xmlns:gp="clr-namespace:Finmer.Gameplay"
     mc:Ignorable="d"
     d:DesignHeight="300" d:DesignWidth="300">
-    <!--<ItemsControl.ItemContainerStyle>
-        <Style TargetType="vm:ItemIconViewModel" />
-    </ItemsControl.ItemContainerStyle>-->
     <ListBox.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <Style TargetType="ListBoxItem">
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ListBoxItem">
-                        <ControlTemplate.Resources>
-                            <Style x:Key="ItemBorderStyle" TargetType="{x:Type Border}">
-                                <Setter Property="Background" Value="Transparent" />
-                                <Setter Property="BorderThickness" Value="2" />
-                            </Style>
-                        </ControlTemplate.Resources>
-                        <Border x:Name="Border" Style="{StaticResource ItemBorderStyle}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" d:DataContext="{d:DesignInstance gp:Item}" ToolTipService.ShowDuration="12000">
-                            <StackPanel Orientation="Horizontal">
-                                <v:ItemIconView Margin="2" />
-                                <TextBlock Text="{Binding Asset.ObjectName}" Style="{StaticResource TextBlockDefault}" VerticalAlignment="Center" Margin="4,0,0,0" />
+                        <Border
+                            x:Name="Border"
+                            VerticalAlignment="Stretch"
+                            HorizontalAlignment="Stretch"
+                            d:DataContext="{d:DesignInstance gp:Item}">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Background" Value="Transparent" />
+                                    <Setter Property="BorderThickness" Value="2" />
+                                </Style>
+                            </Border.Style>
+                            <StackPanel Orientation="Vertical">
+                                <!-- Item icon and name -->
+                                <StackPanel Orientation="Horizontal">
+                                    <v:ItemIconView Margin="2" />
+                                    <TextBlock
+                                        Text="{Binding Asset.ObjectName}"
+                                        Style="{StaticResource TextBlockDefault}"
+                                        VerticalAlignment="Center"
+                                        Margin="4,0,0,0" />
+                                </StackPanel>
+
+                                <!-- Item actions -->
+                                <ContentControl
+                                    Visibility="{Binding IsSelected, RelativeSource={RelativeSource FindAncestor, AncestorType=ListBoxItem}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    Template="{Binding ItemOptionsTemplate, RelativeSource={RelativeSource FindAncestor, AncestorType=v:ItemListView}}" />
                             </StackPanel>
                             <Border.ToolTip>
+                                <!-- Item tooltip -->
                                 <v:ItemTooltipView DataContext="{TemplateBinding Content}" />
                             </Border.ToolTip>
                         </Border>
                         <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-                            </Trigger>
+                            <!-- Highlight background when row is selected -->
                             <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource DepressedBrush}" />
                                 <Setter TargetName="Border" Property="Background" Value="{StaticResource BrightBackgroundBrush}" />
+                            </Trigger>
+                            <!-- Highlight border when hovered -->
+                            <Trigger Property="IsMouseOver" Value="True">
                                 <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
                             </Trigger>
                         </ControlTemplate.Triggers>
@@ -47,8 +64,15 @@
     </ListBox.Resources>
     <ListBox.Template>
         <ControlTemplate>
-            <ScrollViewer Margin="0" Focusable="false" VerticalScrollBarVisibility="Auto" CanContentScroll="True">
-                <VirtualizingStackPanel Margin="2" IsItemsHost="True" />
+            <ScrollViewer
+                HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto"
+                CanContentScroll="false">
+                <StackPanel
+                    Margin="2"
+                    VerticalAlignment="Top"
+                    Orientation="Vertical"
+                    IsItemsHost="True" />
             </ScrollViewer>
         </ControlTemplate>
     </ListBox.Template>

--- a/Finmer.Game/Views/ItemListView.xaml.cs
+++ b/Finmer.Game/Views/ItemListView.xaml.cs
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using System.Windows;
+using System.Windows.Controls;
+
 namespace Finmer.Views
 {
 
@@ -14,6 +17,21 @@ namespace Finmer.Views
     /// </summary>
     public partial class ItemListView
     {
+
+        /// <summary>
+        /// Dependency property for ItemOptionsTemplate.
+        /// </summary>
+        public static readonly DependencyProperty ItemOptionsTemplateProperty = DependencyProperty.Register(
+            "ItemOptionsTemplate", typeof(ControlTemplate), typeof(ItemListView), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Template shown at the bottom of the item widget when selected by the user.
+        /// </summary>
+        public ControlTemplate ItemOptionsTemplate
+        {
+            get => (ControlTemplate)GetValue(ItemOptionsTemplateProperty);
+            set => SetValue(ItemOptionsTemplateProperty, value);
+        }
 
         public ItemListView()
         {

--- a/Finmer.Game/Views/ItemTooltipView.xaml
+++ b/Finmer.Game/Views/ItemTooltipView.xaml
@@ -10,7 +10,9 @@
     d:DataContext="{d:DesignInstance gp:Item}"
     Loaded="UserControl_Loaded">
     <StackPanel>
-        <!--<TextBlock Text="{Binding Name}" Style="{StaticResource TextBlockDefault}" FontWeight="Bold" Margin="0,0,0,15" />-->
-        <TextBlock Name="ItemInfoLabel" Style="{StaticResource TextBlockDefault}" MaxWidth="300" TextWrapping="Wrap" />
+        <TextBlock Name="ItemInfoLabel"
+            Style="{StaticResource TextBlockDefault}"
+            MaxWidth="300"
+            TextWrapping="Wrap" />
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
Rebuilding the internals of the character sheet to improve maintainability, and to separate out some reusable components.

For example I'd like to be able to reuse the ItemListView component for the shop system later on, so we don't have to maintain two components that do basically the same thing (showing a list of items). Currently there's the ItemShopListView for that, but I'd like to get rid of it.

Goals:
- Clean up ancient, messy code
- Reduce the amount of code in CharSheetPage.xaml.cs in general
- Refactor things to make better use of the MVVM pattern
- Prepare for making the character sheet a standalone widget, so it can eventually be displayed on top of the main page
- Prepare for re-implementation of Usable items
- Prepare for re-implementation of the shop system

Currently a work-in-progress.

Todo list:
- [x] Create a viewmodel that contains all the displayed state for the page
- [x] Clean up ItemBoxView
- [x] Clean up ItemListView
- [x] Figure out a good spot to place the Unequip button
- [x] Repair the Use/Equip button (placeholder is good enough, item scripts will come later)
- [x] Repair the Drop button
- [x] Repair the Unequip button
