### PR TITLE
Fix gender options in character creation screen not applying properly

### DIFF
--- a/Finmer.Game/Views/CharCreateBasic.xaml
+++ b/Finmer.Game/Views/CharCreateBasic.xaml
@@ -52,7 +52,7 @@
         <TextBlock Margin="0,30,0,0" Style="{StaticResource TextBlockDefault}" Text="Sex:" />
         <TextBlock Style="{StaticResource TextBlockSubtle}"
             Text="Mostly aesthetic (pronouns etc.) but can affect dialogue." />
-        <RadioButton x:Name="optGenderMale" IsChecked="True" Checked="optGender_Checked">Male</RadioButton>
+        <RadioButton x:Name="optGenderMale" Checked="optGender_Checked">Male</RadioButton>
         <RadioButton x:Name="optGenderFemale" Checked="optGender_Checked">Female</RadioButton>
     </StackPanel>
 </vb:CharCreateViewBase>

--- a/Finmer.Game/Views/CharCreateBasic.xaml.cs
+++ b/Finmer.Game/Views/CharCreateBasic.xaml.cs
@@ -35,8 +35,12 @@ namespace Finmer.Views
         {
             txtName.Text = InitialSaveData.GetString("name");
             cmbSpecies.Text = InitialSaveData.GetString("species");
-            optGenderMale.IsChecked = InitialSaveData.GetString("gender").Equals("Male");
-            optGenderFemale.IsChecked = !optGenderMale.IsChecked;
+            //check if there was some initial value saved in the gender field, if not we go without anything checked.
+            if (!String.IsNullOrWhiteSpace(InitialSaveData.GetString("gender")))
+            {
+                optGenderMale.IsChecked = InitialSaveData.GetString("gender").Equals("Male");
+                optGenderFemale.IsChecked = !optGenderMale.IsChecked;
+            }
             m_Setup = false;
 
             // Apply some default settings to enable quickly clicking through to the game

--- a/Finmer.Game/Views/CharCreateBasic.xaml.cs
+++ b/Finmer.Game/Views/CharCreateBasic.xaml.cs
@@ -35,8 +35,11 @@ namespace Finmer.Views
         {
             txtName.Text = InitialSaveData.GetString("name");
             cmbSpecies.Text = InitialSaveData.GetString("species");
-            optGenderMale.IsChecked = InitialSaveData.GetString("gender").Equals("Male");
-            optGenderFemale.IsChecked = !optGenderMale.IsChecked;            
+            if (!String.IsNullOrWhiteSpace(InitialSaveData.GetString("gender")))
+            {
+                optGenderMale.IsChecked = InitialSaveData.GetString("gender").Equals("Male");
+                optGenderFemale.IsChecked = !optGenderMale.IsChecked;
+            }
             m_Setup = false;
 
             // Apply some default settings to enable quickly clicking through to the game

--- a/Finmer.Game/Views/CharCreateBasic.xaml.cs
+++ b/Finmer.Game/Views/CharCreateBasic.xaml.cs
@@ -47,18 +47,10 @@ namespace Finmer.Views
             {
                 txtName.Text = "Snack";
                 cmbSpecies.SelectedIndex = CoreUtility.Rng.Next(cmbSpecies.Items.Count);
-                //make a coin flip to see if it's male or female randomly selected, then set the gender accordingly.
-                int genderFlip = CoreUtility.Rng.Next(2);
-                if (genderFlip == 0) 
-                {
-                    optGenderMale.IsChecked = true;
-                    optGenderFemale.IsChecked = !optGenderMale.IsChecked;
-                }
-                else
-                {
-                    optGenderMale.IsChecked = false;
-                    optGenderFemale.IsChecked = !optGenderMale.IsChecked;
-                }
+                // Make a coin flip to see if it's male or female randomly selected, then set the gender accordingly.
+                int gender_flip = CoreUtility.Rng.Next(2);
+                optGenderMale.IsChecked = (gender_flip == 0);
+                optGenderFemale.IsChecked = !optGenderMale.IsChecked;
                 ValidateForm();
             }
         }
@@ -92,7 +84,6 @@ namespace Finmer.Views
 
         private void ValidateForm()
         {
-            //add additional check to make sure radio button has been selected.
             m_CanGoNext =
                 !String.IsNullOrWhiteSpace(InitialSaveData.GetString("name")) && 
                 !String.IsNullOrWhiteSpace(InitialSaveData.GetString("species")) &&

--- a/Finmer.Game/Views/CharCreateBasic.xaml.cs
+++ b/Finmer.Game/Views/CharCreateBasic.xaml.cs
@@ -35,12 +35,8 @@ namespace Finmer.Views
         {
             txtName.Text = InitialSaveData.GetString("name");
             cmbSpecies.Text = InitialSaveData.GetString("species");
-            //check if there was some initial value saved in the gender field, if not we go without anything checked.
-            if (!String.IsNullOrWhiteSpace(InitialSaveData.GetString("gender")))
-            {
-                optGenderMale.IsChecked = InitialSaveData.GetString("gender").Equals("Male");
-                optGenderFemale.IsChecked = !optGenderMale.IsChecked;
-            }
+            optGenderMale.IsChecked = InitialSaveData.GetString("gender").Equals("Male");
+            optGenderFemale.IsChecked = !optGenderMale.IsChecked;            
             m_Setup = false;
 
             // Apply some default settings to enable quickly clicking through to the game
@@ -48,6 +44,18 @@ namespace Finmer.Views
             {
                 txtName.Text = "Snack";
                 cmbSpecies.SelectedIndex = CoreUtility.Rng.Next(cmbSpecies.Items.Count);
+                //make a coin flip to see if it's male or female randomly selected, then set the gender accordingly.
+                int genderFlip = CoreUtility.Rng.Next(2);
+                if (genderFlip == 0) 
+                {
+                    optGenderMale.IsChecked = true;
+                    optGenderFemale.IsChecked = !optGenderMale.IsChecked;
+                }
+                else
+                {
+                    optGenderMale.IsChecked = false;
+                    optGenderFemale.IsChecked = !optGenderMale.IsChecked;
+                }
                 ValidateForm();
             }
         }

--- a/Finmer.Game/Views/CharCreateBasic.xaml.cs
+++ b/Finmer.Game/Views/CharCreateBasic.xaml.cs
@@ -77,9 +77,11 @@ namespace Finmer.Views
 
         private void ValidateForm()
         {
+            //add additional check to make sure radio button has been selected.
             m_CanGoNext =
                 !String.IsNullOrWhiteSpace(InitialSaveData.GetString("name")) && 
-                !String.IsNullOrWhiteSpace(InitialSaveData.GetString("species"));
+                !String.IsNullOrWhiteSpace(InitialSaveData.GetString("species")) &&
+                !String.IsNullOrWhiteSpace(InitialSaveData.GetString("gender"));
             OnPropertyChanged(nameof(CanGoNext));
         }
 


### PR DESCRIPTION
Actually, I did manage to get the randomized option for the gender radio buttons to work. so I think this operates now as you want it to do.

I have a feeling that the default settings will not save for very long, so I added a bit to the setup portion with regards to checking if the Gender field is filled with anything or not. This means the settings will keep swapping, but right now dodging between the character creation screens already changes the species and reverts the name to "Snack" so I think that now the gender is right to where it should be.