### PR TITLE
Fix grappling in combat breaking swallow requirements

### DIFF
--- a/Finmer.Game/Gameplay/Character.cs
+++ b/Finmer.Game/Gameplay/Character.cs
@@ -296,6 +296,10 @@ namespace Finmer.Gameplay
             return prey.Size <= Size;
         }
 
+        /// <summary>
+        /// Returns a value indicating whether a certain character can be grappled in a fight.
+        /// </summary>
+        /// <param name="victim">The character who may or may not be grabbed.</param>
         public bool CanGrapple(Character victim) 
         {
             return victim.Size <= Size;

--- a/Finmer.Game/Gameplay/Character.cs
+++ b/Finmer.Game/Gameplay/Character.cs
@@ -296,6 +296,10 @@ namespace Finmer.Gameplay
             return prey.Size <= Size;
         }
 
+        public bool CanGrapple(Character victim) 
+        {
+            return victim.Size <= Size;
+        }
     }
 
 }

--- a/Finmer.Game/Gameplay/SceneCombat2.cs
+++ b/Finmer.Game/Gameplay/SceneCombat2.cs
@@ -324,6 +324,9 @@ namespace Finmer.Gameplay
             switch (action)
             {
                 case ECombatAction.Attack:
+                    m_PotentialPlayerTargets = GetViableAttackTargets(m_Player).ToList();
+                    BeginPlayerPotentialTargetSelect(ECombatAction.Attack);
+                    break;
                 case ECombatAction.GrappleInitiate:
                     m_PotentialPlayerTargets = GetViableGrappleTargets(m_Player).ToList();
                     BeginPlayerPotentialTargetSelect(ECombatAction.GrappleInitiate);
@@ -545,7 +548,7 @@ namespace Finmer.Gameplay
                 });
             }
 
-            //Grapple
+            // Grapple
             var grapple_targets = GetViableGrappleTargets(m_Player);
             if (grapple_targets.Any()) 
             {

--- a/Finmer.Game/Gameplay/SceneCombat2.cs
+++ b/Finmer.Game/Gameplay/SceneCombat2.cs
@@ -327,6 +327,7 @@ namespace Finmer.Gameplay
                     m_PotentialPlayerTargets = GetViableAttackTargets(m_Player).ToList();
                     BeginPlayerPotentialTargetSelect(ECombatAction.Attack);
                     break;
+
                 case ECombatAction.GrappleInitiate:
                     m_PotentialPlayerTargets = GetViableGrappleTargets(m_Player).ToList();
                     BeginPlayerPotentialTargetSelect(ECombatAction.GrappleInitiate);
@@ -342,6 +343,10 @@ namespace Finmer.Gameplay
                     break;
 
                 case ECombatAction.GrappleReverse:
+                    m_PotentialPlayerTargets = GetViableGrappleTargets(m_Player).ToList();
+                    BeginPlayerPotentialTargetSelect(ECombatAction.GrappleReverse);
+                    break;
+
                 case ECombatAction.GrappleEscape:
                 case ECombatAction.GrappleRelease:
                     // Perform the action with the grapple partner
@@ -661,12 +666,17 @@ namespace Finmer.Gameplay
                 // Player is being pinned
                 ui.Instruction = $"You're being pinned down by {m_Player.GrapplingWith.Character.Name}! What will you do?";
 
-                ui.AddButton(new ChoiceButtonModel
+                // IF player cannot start the grapple against larger target, make sure they cannot reverse it either.
+                var grapple_targets = GetViableGrappleTargets(m_Player);
+                if (grapple_targets.Any())
                 {
-                    Choice = (int)ECombatAction.GrappleReverse,
-                    Label = "Reverse",
-                    Tooltip = "Attempt to reverse the grapple, so you end up on top."
-                });
+                    ui.AddButton(new ChoiceButtonModel
+                    {
+                        Choice = (int)ECombatAction.GrappleReverse,
+                        Label = "Reverse",
+                        Tooltip = "Attempt to reverse the grapple, so you end up on top."
+                    });
+                }
                 ui.AddButton(new ChoiceButtonModel
                 {
                     Choice = (int)ECombatAction.GrappleEscape,

--- a/Finmer.Game/Gameplay/SceneCombat2.cs
+++ b/Finmer.Game/Gameplay/SceneCombat2.cs
@@ -173,8 +173,19 @@ namespace Finmer.Gameplay
         }
 
         /// <summary>
+        /// Returns participants that the input participant can attempt to grapple with this turn.
+        /// </summary>
+        /// 
+        private IEnumerable<Participant> GetViableGrappleTargets(Participant opponent) 
+        {
+            return GetViableAttackTargets(opponent)
+                .Where(prey => opponent.Character.CanGrapple(prey.Character));
+        }
+
+        /// <summary>
         /// Returns participants that the input participant can attempt to swallow on this turn.
         /// </summary>
+        /// 
         private IEnumerable<Participant> GetViablePreyTargets(Participant predator)
         {
             // If the predator is currently grappling, the only possible prey they can touch now is their grappling opponent
@@ -314,8 +325,8 @@ namespace Finmer.Gameplay
             {
                 case ECombatAction.Attack:
                 case ECombatAction.GrappleInitiate:
-                    m_PotentialPlayerTargets = GetViableAttackTargets(m_Player).ToList();
-                    BeginPlayerPotentialTargetSelect(action);
+                    m_PotentialPlayerTargets = GetViableGrappleTargets(m_Player).ToList();
+                    BeginPlayerPotentialTargetSelect(ECombatAction.GrappleInitiate);
                     break;
 
                 case ECombatAction.Swallow:
@@ -532,6 +543,12 @@ namespace Finmer.Gameplay
                     Label = "Fight",
                     Tooltip = "Attack another character to deal damage."
                 });
+            }
+
+            //Grapple
+            var grapple_targets = GetViableGrappleTargets(m_Player);
+            if (grapple_targets.Any()) 
+            {
                 ui.AddButton(new ChoiceButtonModel
                 {
                     Choice = (int)ECombatAction.GrappleInitiate,

--- a/Finmer.Game/Gameplay/SceneCombat2.cs
+++ b/Finmer.Game/Gameplay/SceneCombat2.cs
@@ -343,10 +343,6 @@ namespace Finmer.Gameplay
                     break;
 
                 case ECombatAction.GrappleReverse:
-                    m_PotentialPlayerTargets = GetViableGrappleTargets(m_Player).ToList();
-                    BeginPlayerPotentialTargetSelect(ECombatAction.GrappleReverse);
-                    break;
-
                 case ECombatAction.GrappleEscape:
                 case ECombatAction.GrappleRelease:
                     // Perform the action with the grapple partner

--- a/Finmer.Game/Gameplay/SceneCombat2.cs
+++ b/Finmer.Game/Gameplay/SceneCombat2.cs
@@ -661,8 +661,7 @@ namespace Finmer.Gameplay
                 ui.Instruction = $"You're being pinned down by {m_Player.GrapplingWith.Character.Name}! What will you do?";
 
                 // If player cannot start the grapple against larger target, make sure they cannot reverse it either.
-                var grapple_targets = GetViableGrappleTargets(m_Player.GrapplingWith);
-                if (grapple_targets.Any())
+               if(m_Player.Character.CanGrapple(m_Player.GrapplingWith.Character))
                 {
                     ui.AddButton(new ChoiceButtonModel
                     {

--- a/Finmer.Game/Gameplay/SceneCombat2.cs
+++ b/Finmer.Game/Gameplay/SceneCombat2.cs
@@ -174,8 +174,7 @@ namespace Finmer.Gameplay
 
         /// <summary>
         /// Returns participants that the input participant can attempt to grapple with this turn.
-        /// </summary>
-        /// 
+        /// </summary> 
         private IEnumerable<Participant> GetViableGrappleTargets(Participant opponent) 
         {
             return GetViableAttackTargets(opponent)
@@ -185,7 +184,6 @@ namespace Finmer.Gameplay
         /// <summary>
         /// Returns participants that the input participant can attempt to swallow on this turn.
         /// </summary>
-        /// 
         private IEnumerable<Participant> GetViablePreyTargets(Participant predator)
         {
             // If the predator is currently grappling, the only possible prey they can touch now is their grappling opponent
@@ -662,8 +660,8 @@ namespace Finmer.Gameplay
                 // Player is being pinned
                 ui.Instruction = $"You're being pinned down by {m_Player.GrapplingWith.Character.Name}! What will you do?";
 
-                // IF player cannot start the grapple against larger target, make sure they cannot reverse it either.
-                var grapple_targets = GetViableGrappleTargets(m_Player);
+                // If player cannot start the grapple against larger target, make sure they cannot reverse it either.
+                var grapple_targets = GetViableGrappleTargets(m_Player.GrapplingWith);
                 if (grapple_targets.Any())
                 {
                     ui.AddButton(new ChoiceButtonModel


### PR DESCRIPTION
--Added CanGrapple method to Character.cs
--Provided all necessary changes for the SceneCombat2.cs file to prevent Grapple as an option with larger, ungrappleable (That's now a word) characters.
- Added a GetViableGrappleTargets IEnumerable
- Changed the HandlePlayerInputDefault method to check for proper grapple targets
- Changed the ShowUIDefault to account for possible grappleable checks.

Note: on tests with proper characters, when attacking them, the system throws an assertion issue with the HandlePlayerInputDefault method. I don't know what that means as it provides very little information to work from. Are you able to look at the code and see what is improperly set?