### PR TITLE
Fix crash when calling GiveItem() with a non-existent item name

### DIFF
--- a/Finmer.Game/Gameplay/Player.cs
+++ b/Finmer.Game/Gameplay/Player.cs
@@ -347,6 +347,8 @@ namespace Finmer.Gameplay
 
             // Instantiate the item and give it to the player
             Item item = Item.FromAsset(ScriptContext.FromLua(L), item_name);
+            if (item==null)
+                return LuaApi.luaL_error(L, "Item not found.");
             self.AddItem(item);
 
             // Display announcement

--- a/Finmer.Game/Gameplay/Player.cs
+++ b/Finmer.Game/Gameplay/Player.cs
@@ -348,7 +348,7 @@ namespace Finmer.Gameplay
             // Instantiate the item and give it to the player
             Item item = Item.FromAsset(ScriptContext.FromLua(L), item_name);
             if (item==null)
-                return LuaApi.luaL_error(L, "Item not found.");
+                return LuaApi.luaL_error(L, $"Failed to load item '{item_name}'");
             self.AddItem(item);
 
             // Display announcement

--- a/Finmer.Game/Gameplay/Player.cs
+++ b/Finmer.Game/Gameplay/Player.cs
@@ -347,7 +347,7 @@ namespace Finmer.Gameplay
 
             // Instantiate the item and give it to the player
             Item item = Item.FromAsset(ScriptContext.FromLua(L), item_name);
-            if (item==null)
+            if (item == null)
                 return LuaApi.luaL_error(L, $"Failed to load item '{item_name}'");
             self.AddItem(item);
 


### PR DESCRIPTION
Now plays an error message involving the item that failed to load, instead of outright crashing the game.