### PR TITLE
Configure link nodes to select target nodes on double-click

### DIFF
--- a/Finmer.Editor/FormDocumentScene.Designer.cs
+++ b/Finmer.Editor/FormDocumentScene.Designer.cs
@@ -267,7 +267,7 @@
             this.trvNodes.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.trvNodes_AfterSelect);
             this.trvNodes.DragDrop += new System.Windows.Forms.DragEventHandler(this.trvNodes_DragDrop);
             this.trvNodes.DragOver += new System.Windows.Forms.DragEventHandler(this.trvNodes_DragOver);
-            this.trvNodes.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.trvNodes_Link_DoubleClick);
+            this.trvNodes.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.trvNodes_NodeMouseDoubleClick);
             // 
             // imlNodeIcons
             // 

--- a/Finmer.Editor/FormDocumentScene.Designer.cs
+++ b/Finmer.Editor/FormDocumentScene.Designer.cs
@@ -267,7 +267,7 @@
             this.trvNodes.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.trvNodes_AfterSelect);
             this.trvNodes.DragDrop += new System.Windows.Forms.DragEventHandler(this.trvNodes_DragDrop);
             this.trvNodes.DragOver += new System.Windows.Forms.DragEventHandler(this.trvNodes_DragOver);
-            this.trvNodes.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.trvLink_DoubleClick);
+            this.trvNodes.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.trvNodes_Link_DoubleClick);
             // 
             // imlNodeIcons
             // 

--- a/Finmer.Editor/FormDocumentScene.Designer.cs
+++ b/Finmer.Editor/FormDocumentScene.Designer.cs
@@ -267,6 +267,7 @@
             this.trvNodes.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.trvNodes_AfterSelect);
             this.trvNodes.DragDrop += new System.Windows.Forms.DragEventHandler(this.trvNodes_DragDrop);
             this.trvNodes.DragOver += new System.Windows.Forms.DragEventHandler(this.trvNodes_DragOver);
+            this.trvNodes.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.trvLink_DoubleClick);
             // 
             // imlNodeIcons
             // 

--- a/Finmer.Editor/FormDocumentScene.cs
+++ b/Finmer.Editor/FormDocumentScene.cs
@@ -510,9 +510,9 @@ namespace Finmer.Editor
             Dirty = true;
         }
 
-        public TreeNode GetTreeNodeByKey(string key) 
+        private TreeNode GetTreeNodeByKey(string key) 
         {
-            //Prepare stack with root TreeNodes in it
+            // Prepare stack with root TreeNodes in it
             Stack<TreeNode> stack = new Stack<TreeNode>();
             foreach (TreeNode root_node in trvNodes.Nodes)
                 stack.Push(root_node);
@@ -539,17 +539,18 @@ namespace Finmer.Editor
             return null;
         }
 
-        private void trvNodes_Link_DoubleClick(object sender, TreeNodeMouseClickEventArgs e) 
+        private void trvNodes_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e) 
         {
-            //Find the type of node that is double-clicked on, and see if it's a link node
+            // Find the type of node that is double-clicked on, and see if it's a link node
             var link_node = e.Node;
             var link_node_sn = (AssetScene.SceneNode)link_node.Tag;
             if (link_node_sn.IsLink)
             {
-                //If node is a link node, jump to the node it's linked to.
+                // If node is a link node, jump to the node it's linked to.
                 var search_key = link_node_sn.LinkTarget;
                 var matching_node = GetTreeNodeByKey(search_key);
-                trvNodes.SelectedNode = matching_node;
+                if(matching_node != null)
+                    trvNodes.SelectedNode = matching_node;
             }
         }
 

--- a/Finmer.Editor/FormDocumentScene.cs
+++ b/Finmer.Editor/FormDocumentScene.cs
@@ -539,13 +539,15 @@ namespace Finmer.Editor
             return null;
         }
 
-        private void trvLink_DoubleClick(object sender, TreeNodeMouseClickEventArgs e) 
+        private void trvNodes_Link_DoubleClick(object sender, TreeNodeMouseClickEventArgs e) 
         {
-            var lnknode = e.Node;
-            var lnknode_sn = (AssetScene.SceneNode)lnknode.Tag;
-            if (lnknode_sn.IsLink)
+            //Find the type of node that is double-clicked on, and see if it's a link node
+            var link_node = e.Node;
+            var link_node_sn = (AssetScene.SceneNode)link_node.Tag;
+            if (link_node_sn.IsLink)
             {
-                var search_key = lnknode_sn.LinkTarget;
+                //If node is a link node, jump to the node it's linked to.
+                var search_key = link_node_sn.LinkTarget;
                 var matching_node = GetTreeNodeByKey(search_key);
                 trvNodes.SelectedNode = matching_node;
             }

--- a/Finmer.Editor/FormDocumentScene.cs
+++ b/Finmer.Editor/FormDocumentScene.cs
@@ -549,7 +549,7 @@ namespace Finmer.Editor
                 // If node is a link node, jump to the node it's linked to.
                 var search_key = link_node_sn.LinkTarget;
                 var matching_node = GetTreeNodeByKey(search_key);
-                if(matching_node != null)
+                if (matching_node != null)
                     trvNodes.SelectedNode = matching_node;
             }
         }

--- a/Finmer.Editor/FormDocumentScene.cs
+++ b/Finmer.Editor/FormDocumentScene.cs
@@ -510,6 +510,47 @@ namespace Finmer.Editor
             Dirty = true;
         }
 
+        public TreeNode GetTreeNodeByKey(string key) 
+        {
+            //Prepare stack with root TreeNodes in it
+            Stack<TreeNode> stack = new Stack<TreeNode>();
+            foreach (TreeNode root_node in trvNodes.Nodes)
+                stack.Push(root_node);
+
+            // Flood-fill down the tree until the requested node is found
+            while (stack.Count > 0)
+            {
+                TreeNode node = stack.Pop();
+                var node_sn = (AssetScene.SceneNode)node.Tag;
+
+                // Links do not have keys
+                if (node_sn.IsLink)
+                    continue;
+
+                // Is this the node we're looking for?
+                if (node_sn.Key.Equals(key))
+                    return node;
+
+                // Recursively examine the node's children
+                foreach (TreeNode child in node.Nodes)
+                    stack.Push(child);
+            }
+
+            return null;
+        }
+
+        private void trvLink_DoubleClick(object sender, TreeNodeMouseClickEventArgs e) 
+        {
+            var lnknode = e.Node;
+            var lnknode_sn = (AssetScene.SceneNode)lnknode.Tag;
+            if (lnknode_sn.IsLink)
+            {
+                var search_key = lnknode_sn.LinkTarget;
+                var matching_node = GetTreeNodeByKey(search_key);
+                trvNodes.SelectedNode = matching_node;
+            }
+        }
+
         private void trvNodes_DragOver(object sender, DragEventArgs e)
         {
             var source = e.Data.GetData(typeof(TreeNode)) as TreeNode;


### PR DESCRIPTION
Editor now allows for link nodes to jump to the target node when you double-click them, easing the search and development process.