### PR TITLE
Add "compressed ints" to the content readers

### DIFF
--- a/Finmer.Core/Assets/AssetCreature.cs
+++ b/Finmer.Core/Assets/AssetCreature.cs
@@ -123,12 +123,12 @@ namespace Finmer.Core.Assets
             // Core stats
             outstream.WriteStringProperty(nameof(ObjectName), ObjectName);
             outstream.WriteStringProperty(nameof(ObjectAlias), ObjectAlias);
-            outstream.WriteInt32Property(nameof(Strength), Strength);
-            outstream.WriteInt32Property(nameof(Agility), Agility);
-            outstream.WriteInt32Property(nameof(Body), Body);
-            outstream.WriteInt32Property(nameof(Wits), Wits);
-            outstream.WriteInt32Property(nameof(Flags), Flags);
-            outstream.WriteInt32Property(nameof(Level), Level);
+            outstream.WriteCompressedInt32Property(nameof(Strength), Strength);
+            outstream.WriteCompressedInt32Property(nameof(Agility), Agility);
+            outstream.WriteCompressedInt32Property(nameof(Body), Body);
+            outstream.WriteCompressedInt32Property(nameof(Wits), Wits);
+            outstream.WriteCompressedInt32Property(nameof(Flags), Flags);
+            outstream.WriteCompressedInt32Property(nameof(Level), Level);
             outstream.WriteEnumProperty(nameof(Size), Size);
             outstream.WriteEnumProperty(nameof(Gender), Gender);
 
@@ -169,12 +169,12 @@ namespace Finmer.Core.Assets
             // Core stats
             ObjectName = instream.ReadStringProperty(nameof(ObjectName));
             ObjectAlias = instream.ReadStringProperty(nameof(ObjectAlias));
-            Strength = instream.ReadInt32Property(nameof(Strength));
-            Agility = instream.ReadInt32Property(nameof(Agility));
-            Body = instream.ReadInt32Property(nameof(Body));
-            Wits = instream.ReadInt32Property(nameof(Wits));
-            Flags = instream.ReadInt32Property(nameof(Flags));
-            Level = instream.ReadInt32Property(nameof(Level));
+            Strength = instream.ReadCompressedInt32Property(nameof(Strength));
+            Agility = instream.ReadCompressedInt32Property(nameof(Agility));
+            Body = instream.ReadCompressedInt32Property(nameof(Body));
+            Wits = instream.ReadCompressedInt32Property(nameof(Wits));
+            Flags = instream.ReadCompressedInt32Property(nameof(Flags));
+            Level = instream.ReadCompressedInt32Property(nameof(Level));
             Size = instream.ReadEnumProperty<ESize>(nameof(Size));
             Gender = instream.ReadEnumProperty<EGender>(nameof(Gender));
 

--- a/Finmer.Core/Assets/AssetItem.cs
+++ b/Finmer.Core/Assets/AssetItem.cs
@@ -131,7 +131,7 @@ namespace Finmer.Core.Assets
                 }
                 outstream.EndArray();
             }
-            outstream.WriteInt32Property(nameof(PurchaseValue), PurchaseValue);
+            outstream.WriteCompressedInt32Property(nameof(PurchaseValue), PurchaseValue);
             outstream.WriteBooleanProperty(nameof(IsQuestItem), IsQuestItem);
 
             // Usable item data
@@ -166,7 +166,7 @@ namespace Finmer.Core.Assets
                     EquipEffects.Add(instream.ReadNestedObjectProperty<EquipEffectGroup>(null, version));
                 instream.EndArray();
             }
-            PurchaseValue = instream.ReadInt32Property(nameof(PurchaseValue));
+            PurchaseValue = instream.ReadCompressedInt32Property(nameof(PurchaseValue));
             IsQuestItem = instream.ReadBooleanProperty(nameof(IsQuestItem));
 
             // Usable item data

--- a/Finmer.Core/Assets/AssetJournal.cs
+++ b/Finmer.Core/Assets/AssetJournal.cs
@@ -53,7 +53,7 @@ namespace Finmer.Core.Assets
             foreach (QuestStage stage in Stages)
             {
                 outstream.BeginObject();
-                outstream.WriteInt32Property("Key", stage.Key);
+                outstream.WriteCompressedInt32Property("Key", stage.Key);
                 outstream.WriteStringProperty("Text", stage.Text);
                 outstream.EndObject();
             }
@@ -74,7 +74,7 @@ namespace Finmer.Core.Assets
                 instream.BeginObject();
                 QuestStage stage = new QuestStage
                 {
-                    Key = instream.ReadInt32Property("Key"),
+                    Key = instream.ReadCompressedInt32Property("Key"),
                     Text = instream.ReadStringProperty("Text")
                 };
                 Stages.Add(stage);

--- a/Finmer.Core/Buffs/EquipEffectGroup.cs
+++ b/Finmer.Core/Buffs/EquipEffectGroup.cs
@@ -113,7 +113,7 @@ namespace Finmer.Core.Buffs
                 outstream.WriteEnumProperty(nameof(ProcTarget), ProcTarget);
                 outstream.WriteFloatProperty(nameof(ProcChance), ProcChance);
                 outstream.WriteStringProperty(nameof(ProcStringTableKey), ProcStringTableKey);
-                outstream.WriteInt32Property(nameof(Duration), Duration);
+                outstream.WriteCompressedInt32Property(nameof(Duration), Duration);
             }
 
             // Buff collection
@@ -134,7 +134,7 @@ namespace Finmer.Core.Buffs
                 ProcTarget = instream.ReadEnumProperty<EProcTarget>(nameof(ProcTarget));
                 ProcChance = instream.ReadFloatProperty(nameof(ProcChance));
                 ProcStringTableKey = instream.ReadStringProperty(nameof(ProcStringTableKey));
-                Duration = instream.ReadInt32Property(nameof(Duration));
+                Duration = instream.ReadCompressedInt32Property(nameof(Duration));
             }
 
             // Buff collection

--- a/Finmer.Core/Serialization/AssetSerializer.cs
+++ b/Finmer.Core/Serialization/AssetSerializer.cs
@@ -122,7 +122,7 @@ namespace Finmer.Core.Serialization
                 // Read the serialized asset as if it's a new object, thus effectively duplicating it
                 using (var reader = new BinaryReader(ms, Encoding.UTF8, true))
                 {
-                    var deserializer = new FurballContentReaderBinary(reader);
+                    var deserializer = new FurballContentReaderBinary(reader, FurballFileDevice.k_LatestVersion);
                     return (TAsset)DeserializeAsset(deserializer, FurballFileDevice.k_LatestVersion);
                 }
             }

--- a/Finmer.Core/Serialization/FurballContentReaderBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentReaderBinary.cs
@@ -20,10 +20,12 @@ namespace Finmer.Core.Serialization
     {
 
         private readonly BinaryReader m_Stream;
+        private readonly int m_Version;
 
-        public FurballContentReaderBinary(BinaryReader instream)
+        public FurballContentReaderBinary(BinaryReader instream, int version)
         {
             m_Stream = instream;
+            m_Version = version;
         }
 
         public bool ReadBooleanProperty(string key)

--- a/Finmer.Core/Serialization/FurballContentReaderBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentReaderBinary.cs
@@ -107,8 +107,10 @@ namespace Finmer.Core.Serialization
 
         public byte[] ReadByteArrayProperty(string key)
         {
-            int length = m_Stream.ReadInt32();
-            if (length < 0)
+            // In versions <= 20, we used to write -1 for null byte arrays (we now write 0)
+            // This method will handle that fine, since it delegates to ReadInt32Property in those versions
+            int length = ReadCompressedInt32Property(null);
+            if (length <= 0)
                 return null;
 
             return m_Stream.ReadBytes(length);
@@ -148,7 +150,7 @@ namespace Finmer.Core.Serialization
 
         public int BeginArray(string key)
         {
-            return m_Stream.ReadInt32();
+            return ReadCompressedInt32Property(null);
         }
 
         public void EndObject()

--- a/Finmer.Core/Serialization/FurballContentReaderBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentReaderBinary.cs
@@ -43,6 +43,31 @@ namespace Finmer.Core.Serialization
             return m_Stream.ReadInt32();
         }
 
+        public int ReadCompressedInt32Property(string key)
+        {
+            // In versions 20 and below, these were plain uncompressed integers
+            if (m_Version < 21)
+                return ReadInt32Property(key);
+
+            // The following is a re-implementation of Read7BitEncodedInt() from BinaryReader
+
+            int read_value = 0; // The value being read
+            int shift = 0;      // The position of the next seven bits
+            byte next;          // The next byte to be read
+
+            do {
+                if (shift == 5 * 7)
+                    throw new FormatException("Int too long");
+
+                next = m_Stream.ReadByte();
+
+                read_value |= (next & 0x7F) << shift;
+                shift += 7;
+            } while ((next & 0x80u) != 0);
+
+            return read_value;
+        }
+
         public float ReadFloatProperty(string key)
         {
             return m_Stream.ReadSingle();

--- a/Finmer.Core/Serialization/FurballContentWriterBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentWriterBinary.cs
@@ -44,16 +44,7 @@ namespace Finmer.Core.Serialization
 
         public void WriteCompressedInt32Property(string key, int value)
         {
-            // The following is a re-implementation of Write7BitEncodedInt() from BinaryWriter
-
-            uint unsigned_value = (uint)value;
-
-            while (unsigned_value >= 0x80u) {
-                m_Stream.Write((byte) (unsigned_value | 0x80u));
-                unsigned_value >>= 7;
-            }
-
-            m_Stream.Write((byte)unsigned_value);
+            Write7BitEncodedInt(value);
         }
 
         public void WriteFloatProperty(string key, float value)
@@ -98,14 +89,14 @@ namespace Finmer.Core.Serialization
         {
             if (value == null)
             {
-                WriteCompressedInt32Property(null, 0);
+                Write7BitEncodedInt(0);
             }
             else
             {
                 if (value.Length == 0)
                     throw new ArgumentException("Attempt to write zero-length byte array", "value");
 
-                WriteCompressedInt32Property(null, value.Length);
+                Write7BitEncodedInt(value.Length);
                 m_Stream.Write(value);
             }
         }
@@ -142,7 +133,7 @@ namespace Finmer.Core.Serialization
 
         public void BeginArray(string key, int numElements)
         {
-            WriteCompressedInt32Property(null, numElements);
+            Write7BitEncodedInt(numElements);
         }
 
         public void EndObject()
@@ -153,6 +144,20 @@ namespace Finmer.Core.Serialization
         public void EndArray()
         {
             // Irrelevant for binary objects
+        }
+
+        private void Write7BitEncodedInt(int value)
+        {
+            // The following is a re-implementation of Write7BitEncodedInt() from BinaryWriter
+
+            uint unsigned_value = (uint)value;
+
+            while (unsigned_value >= 0x80u) {
+                m_Stream.Write((byte) (unsigned_value | 0x80u));
+                unsigned_value >>= 7;
+            }
+
+            m_Stream.Write((byte)unsigned_value);
         }
 
     }

--- a/Finmer.Core/Serialization/FurballContentWriterBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentWriterBinary.cs
@@ -98,11 +98,14 @@ namespace Finmer.Core.Serialization
         {
             if (value == null)
             {
-                m_Stream.Write(-1);
+                WriteCompressedInt32Property(null, 0);
             }
             else
             {
-                m_Stream.Write(value.Length);
+                if (value.Length == 0)
+                    throw new ArgumentException("Attempt to write zero-length byte array", "value");
+
+                WriteCompressedInt32Property(null, value.Length);
                 m_Stream.Write(value);
             }
         }
@@ -139,7 +142,7 @@ namespace Finmer.Core.Serialization
 
         public void BeginArray(string key, int numElements)
         {
-            m_Stream.Write(numElements);
+            WriteCompressedInt32Property(null, numElements);
         }
 
         public void EndObject()

--- a/Finmer.Core/Serialization/FurballContentWriterBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentWriterBinary.cs
@@ -42,6 +42,20 @@ namespace Finmer.Core.Serialization
             m_Stream.Write(value);
         }
 
+        public void WriteCompressedInt32Property(string key, int value)
+        {
+            // The following is a re-implementation of Write7BitEncodedInt() from BinaryWriter
+
+            uint unsigned_value = (uint)value;
+
+            while (unsigned_value >= 0x80u) {
+                m_Stream.Write((byte) (unsigned_value | 0x80u));
+                unsigned_value >>= 7;
+            }
+
+            m_Stream.Write((byte)unsigned_value);
+        }
+
         public void WriteFloatProperty(string key, float value)
         {
             m_Stream.Write(value);

--- a/Finmer.Core/Serialization/FurballContentWriterBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentWriterBinary.cs
@@ -94,7 +94,7 @@ namespace Finmer.Core.Serialization
             else
             {
                 if (value.Length == 0)
-                    throw new ArgumentException("Attempt to write zero-length byte array", "value");
+                    throw new ArgumentException("Attempt to write zero-length byte array", nameof(value));
 
                 Write7BitEncodedInt(value.Length);
                 m_Stream.Write(value);

--- a/Finmer.Core/Serialization/FurballFileDeviceBinary.cs
+++ b/Finmer.Core/Serialization/FurballFileDeviceBinary.cs
@@ -188,7 +188,7 @@ namespace Finmer.Core.Serialization
         private static AssetBase ReadAssetFromStream(BinaryReader instream, int version)
         {
             // Deserialize an asset of the appropriate type
-            IFurballContentReader content_reader = new FurballContentReaderBinary(instream);
+            IFurballContentReader content_reader = new FurballContentReaderBinary(instream, version);
             AssetBase asset = AssetSerializer.DeserializeAsset(content_reader, version) as AssetBase;
             if (asset == null)
                 throw new FurballInvalidAssetException("Could not parse asset in stream");

--- a/Finmer.Core/Serialization/IFurballContentReader.cs
+++ b/Finmer.Core/Serialization/IFurballContentReader.cs
@@ -40,6 +40,12 @@ namespace Finmer.Core.Serialization
         int ReadInt32Property(string key);
 
         /// <summary>
+        /// Read the value of a 32-bit integer property that was written with the corresponding method in IFurballContentWriter.
+        /// </summary>
+        /// <param name="key">The key of the key/value pair, to be used in content formats that support named keys.</param>
+        int ReadCompressedInt32Property(string key);
+
+        /// <summary>
         /// Read the value of a 32-bit float property.
         /// </summary>
         /// <param name="key">The key of the key/value pair, to be used in content formats that support named keys.</param>

--- a/Finmer.Core/Serialization/IFurballContentReader.cs
+++ b/Finmer.Core/Serialization/IFurballContentReader.cs
@@ -70,7 +70,7 @@ namespace Finmer.Core.Serialization
         string ReadStringProperty(string key);
 
         /// <summary>
-        /// Read the value of a byte array property.
+        /// Read the value of a byte array property, which may be null.
         /// </summary>
         /// <param name="key">The key of the key/value pair, to be used in content formats that support named keys.</param>
         byte[] ReadByteArrayProperty(string key);
@@ -111,7 +111,7 @@ namespace Finmer.Core.Serialization
         void EndObject();
 
         /// <summary>
-        /// Exit out of an array that was opened with BeginObject(). This function must be called an equal number of times as BeginObject().
+        /// Exit out of an array that was opened with BeginArray(). This function must be called an equal number of times as BeginArray().
         /// </summary>
         void EndArray();
 

--- a/Finmer.Core/Serialization/IFurballContentWriter.cs
+++ b/Finmer.Core/Serialization/IFurballContentWriter.cs
@@ -62,8 +62,10 @@ namespace Finmer.Core.Serialization
         void WriteStringProperty(string key, string value);
 
         /// <summary>
-        /// Write a key/value-pair with the specified value.
+        /// Write a byte array with the specified key.
+        /// The byte array may be null, but it may not be empty, and an exception is thrown in this case.
         /// </summary>
+        /// <exception cref="ArgumentException">Thrown when attempting to write a zero-length byte array.</exception>
         void WriteByteArrayProperty(string key, byte[] value);
 
         /// <summary>
@@ -102,7 +104,7 @@ namespace Finmer.Core.Serialization
         void EndObject();
 
         /// <summary>
-        /// Close an array that was opened with BeginArray(). This function must be called an equal number of times as BeginObject().
+        /// Close an array that was opened with BeginArray(). This function must be called an equal number of times as BeginArray().
         /// </summary>
         void EndArray();
 

--- a/Finmer.Core/Serialization/IFurballContentWriter.cs
+++ b/Finmer.Core/Serialization/IFurballContentWriter.cs
@@ -33,6 +33,15 @@ namespace Finmer.Core.Serialization
         void WriteInt32Property(string key, int value);
 
         /// <summary>
+        /// Writes a 32-bit integer associated with the specified key.
+        /// The integer may be compressed in a format chosen by the implementation, although this is not required;
+        /// an implementation may choose to write the number normally.
+        /// </summary>
+        /// <param name="key">The key of the key/value pair, to be used in content formats that support named keys.</param>
+        /// <param name="value">The number to be written.</param>
+        void WriteCompressedInt32Property(string key, int value);
+
+        /// <summary>
         /// Write a key/value-pair with the specified value.
         /// </summary>
         void WriteFloatProperty(string key, float value);

--- a/Finmer.Core/VisualScripting/Nodes/CommandCombatApplyBuff.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandCombatApplyBuff.cs
@@ -97,7 +97,7 @@ namespace Finmer.Core.VisualScripting.Nodes
                 outstream.WriteStringProperty(nameof(ParticipantID), ParticipantID);
 
             outstream.WriteNestedObjectProperty(nameof(Effect), Effect);
-            outstream.WriteInt32Property(nameof(Duration), Duration);
+            outstream.WriteCompressedInt32Property(nameof(Duration), Duration);
         }
 
         public override void Deserialize(IFurballContentReader instream, int version)
@@ -108,7 +108,7 @@ namespace Finmer.Core.VisualScripting.Nodes
                 ParticipantID = instream.ReadStringProperty(nameof(ParticipantID));
 
             Effect = instream.ReadNestedObjectProperty<Buff>(nameof(Effect), version);
-            Duration = instream.ReadInt32Property(nameof(Duration));
+            Duration = instream.ReadCompressedInt32Property(nameof(Duration));
         }
 
         private string GetLuaBuffCtor()

--- a/Finmer.Core/VisualScripting/Nodes/CommandJournalUpdate.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandJournalUpdate.cs
@@ -56,14 +56,14 @@ namespace Finmer.Core.VisualScripting.Nodes
         public override void Serialize(IFurballContentWriter outstream)
         {
             outstream.WriteGuidProperty(nameof(JournalGuid), JournalGuid);
-            outstream.WriteInt32Property(nameof(Stage), Stage);
+            outstream.WriteCompressedInt32Property(nameof(Stage), Stage);
         }
 
 
         public override void Deserialize(IFurballContentReader instream, int version)
         {
             JournalGuid = instream.ReadGuidProperty(nameof(JournalGuid));
-            Stage = instream.ReadInt32Property(nameof(Stage));
+            Stage = instream.ReadCompressedInt32Property(nameof(Stage));
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPreysense.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPreysense.cs
@@ -86,13 +86,13 @@ namespace Finmer.Core.VisualScripting.Nodes
 
         public override void Serialize(IFurballContentWriter outstream)
         {
-            outstream.WriteInt32Property(nameof(Mode), (int)Mode);
+            outstream.WriteCompressedInt32Property(nameof(Mode), (int)Mode);
             outstream.WriteGuidProperty(nameof(CreatureGuid), CreatureGuid);
         }
 
         public override void Deserialize(IFurballContentReader instream, int version)
         {
-            Mode = (ESenseType)instream.ReadInt32Property(nameof(Mode));
+            Mode = (ESenseType)instream.ReadCompressedInt32Property(nameof(Mode));
             CreatureGuid = instream.ReadGuidProperty(nameof(CreatureGuid));
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandShop.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandShop.cs
@@ -94,7 +94,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             // Basic configuration
             outstream.WriteStringProperty(nameof(Key), Key);
             outstream.WriteStringProperty(nameof(Title), Title);
-            outstream.WriteInt32Property(nameof(RestockInterval), RestockInterval);
+            outstream.WriteCompressedInt32Property(nameof(RestockInterval), RestockInterval);
 
             // Merchandise list
             outstream.BeginArray(nameof(Merchandise), Merchandise.Count);
@@ -102,7 +102,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             {
                 outstream.BeginObject();
                 outstream.WriteGuidProperty(@"Item", stock.Key);
-                outstream.WriteInt32Property(@"Quantity", stock.Value);
+                outstream.WriteCompressedInt32Property(@"Quantity", stock.Value);
                 outstream.EndObject();
             }
             outstream.EndArray();
@@ -113,14 +113,14 @@ namespace Finmer.Core.VisualScripting.Nodes
             // Basic configuration
             Key = instream.ReadStringProperty(nameof(Key));
             Title = instream.ReadStringProperty(nameof(Title));
-            RestockInterval = instream.ReadInt32Property(nameof(RestockInterval));
+            RestockInterval = instream.ReadCompressedInt32Property(nameof(RestockInterval));
 
             // Merchandise list
             Merchandise.Clear();
             for (int i = 0, c = instream.BeginArray(nameof(Merchandise)); i < c; i++)
             {
                 instream.BeginObject();
-                Merchandise.Add(instream.ReadGuidProperty(@"Item"), instream.ReadInt32Property(@"Quantity"));
+                Merchandise.Add(instream.ReadGuidProperty(@"Item"), instream.ReadCompressedInt32Property(@"Quantity"));
                 instream.EndObject();
             }
             instream.EndArray();

--- a/Finmer.Editor/FurballContentReaderText.cs
+++ b/Finmer.Editor/FurballContentReaderText.cs
@@ -75,6 +75,12 @@ namespace Finmer.Editor
             }
         }
 
+        public int ReadCompressedInt32Property(string key)
+        {
+            // We don't do any special compression here, just redirect to the normal version
+            return ReadInt32Property(key);
+        }
+
         public float ReadFloatProperty(string key)
         {
             try

--- a/Finmer.Editor/FurballContentWriterText.cs
+++ b/Finmer.Editor/FurballContentWriterText.cs
@@ -48,6 +48,12 @@ namespace Finmer.Editor
             m_Stream.WriteValue(value);
         }
 
+        public void WriteCompressedInt32Property(string key, int value)
+        {
+            // We don't do any special compression here, just redirect to the normal version
+            WriteInt32Property(key, value);
+        }
+
         public void WriteFloatProperty(string key, float value)
         {
             m_Stream.WritePropertyName(key);

--- a/Finmer.Game/Gameplay/SaveData.cs
+++ b/Finmer.Game/Gameplay/SaveData.cs
@@ -142,7 +142,7 @@ namespace Finmer.Gameplay
                 try
                 {
                     // Reconstruct and deserialize the asset
-                    var reader = new FurballContentReaderBinary(br);
+                    var reader = new FurballContentReaderBinary(br, FurballFileDevice.k_LatestVersion);
                     var result = AssetSerializer.DeserializeAsset(reader, FurballFileDevice.k_LatestVersion) as TAsset;
 
                     // If casting failed, the asset was of some unexpected type


### PR DESCRIPTION
Here's the 7-bit stuff. It introduces two methods for reading and writing optionally-compressed ints and switches a bunch of stuff to use them. The methods are for plain old ints, since unsigned ones looked like they'd involve a large number of casts (unless the fields were changed).

I did change the byte arrays (and by extension attachments) to represent `null` using 0. To avoid zero-length arrays being reinterpreted as `null`, I've made it an error to write such arrays. (See that commit for details.)

I also wanted to ask why `CommandShop` *shouldn't* be converted to use these methods, since both of the `int` fields seem fine. I assume I'm just missing something here -- regardless, I've left these and the other specified uses untouched.

A minor thing, but I also corrected the docs on `EndArray()` while I was there (they referenced `BeginObject()` instead of `BeginArray()`).