### PR TITLE
Refactor deserialization format version access to go through the reader

### DIFF
--- a/Finmer.Core/Assets/AssetBase.cs
+++ b/Finmer.Core/Assets/AssetBase.cs
@@ -45,7 +45,7 @@ namespace Finmer.Core.Assets
         /// <summary>
         /// Load the asset from a stream, overwriting existing data.
         /// </summary>
-        public virtual void Deserialize(IFurballContentReader instream, int version)
+        public virtual void Deserialize(IFurballContentReader instream)
         {
             ID = instream.ReadGuidProperty(@"AssetID");
             Name = instream.ReadStringProperty(@"AssetName");

--- a/Finmer.Core/Assets/AssetCreature.cs
+++ b/Finmer.Core/Assets/AssetCreature.cs
@@ -162,9 +162,9 @@ namespace Finmer.Core.Assets
             outstream.EndArray();
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
 
             // Core stats
             ObjectName = instream.ReadStringProperty(nameof(ObjectName));

--- a/Finmer.Core/Assets/AssetItem.cs
+++ b/Finmer.Core/Assets/AssetItem.cs
@@ -148,9 +148,9 @@ namespace Finmer.Core.Assets
             outstream.WriteAttachment(GetIconAttachmentName(), InventoryIcon);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
 
             // Core stats
             ObjectName = instream.ReadStringProperty(nameof(ObjectName));
@@ -163,7 +163,7 @@ namespace Finmer.Core.Assets
 
                 // V19 onwards: equip effect groups with nested buffs and proc settings
                 for (int count = instream.BeginArray(nameof(EquipEffects)); count > 0; count--)
-                    EquipEffects.Add(instream.ReadNestedObjectProperty<EquipEffectGroup>(null, version));
+                    EquipEffects.Add(instream.ReadNestedObjectProperty<EquipEffectGroup>(null));
                 instream.EndArray();
             }
             PurchaseValue = instream.ReadCompressedInt32Property(nameof(PurchaseValue));
@@ -178,7 +178,7 @@ namespace Finmer.Core.Assets
                 UseDescription = instream.ReadStringProperty(nameof(UseDescription));
 
                 // Read attached UseScript, or if there is none, instantiate one now
-                UseScript = instream.ReadNestedObjectProperty<AssetScript>(nameof(UseScript), version)
+                UseScript = instream.ReadNestedObjectProperty<AssetScript>(nameof(UseScript))
                     ?? new AssetScript { ID = Guid.NewGuid() };
 
                 // Ensure the script is named

--- a/Finmer.Core/Assets/AssetJournal.cs
+++ b/Finmer.Core/Assets/AssetJournal.cs
@@ -60,9 +60,9 @@ namespace Finmer.Core.Assets
             outstream.EndArray();
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
 
             // Read metadata
             Title = instream.ReadStringProperty(nameof(Title));

--- a/Finmer.Core/Assets/AssetScene.cs
+++ b/Finmer.Core/Assets/AssetScene.cs
@@ -147,7 +147,7 @@ namespace Finmer.Core.Assets
             ScriptLeave = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptLeave));
 
             // Game start settings
-            if (instream.GetVersion() >= 20)
+            if (instream.GetFormatVersion() >= 20)
             {
                 IsGameStart = instream.ReadBooleanProperty(nameof(IsGameStart));
                 if (IsGameStart)

--- a/Finmer.Core/Assets/AssetScene.cs
+++ b/Finmer.Core/Assets/AssetScene.cs
@@ -137,17 +137,17 @@ namespace Finmer.Core.Assets
             outstream.EndObject();
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
 
             // Read scene scripts
-            ScriptCustom = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptCustom), version);
-            ScriptEnter = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptEnter), version);
-            ScriptLeave = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptLeave), version);
+            ScriptCustom = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptCustom));
+            ScriptEnter = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptEnter));
+            ScriptLeave = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptLeave));
 
             // Game start settings
-            if (version >= 20)
+            if (instream.GetVersion() >= 20)
             {
                 IsGameStart = instream.ReadBooleanProperty(nameof(IsGameStart));
                 if (IsGameStart)
@@ -174,7 +174,7 @@ namespace Finmer.Core.Assets
             // Read the scene node tree recursively
             instream.BeginObject("Root");
             Root = new SceneNode();
-            Root.Deserialize(instream, version);
+            Root.Deserialize(instream);
             instream.EndObject();
         }
 
@@ -354,7 +354,7 @@ namespace Finmer.Core.Assets
                 }
             }
 
-            public void Deserialize(IFurballContentReader instream, int version)
+            public void Deserialize(IFurballContentReader instream)
             {
                 // Core metadata
                 NodeType = instream.ReadEnumProperty<ENodeType>(nameof(NodeType));
@@ -398,8 +398,8 @@ namespace Finmer.Core.Assets
                 if (read_scripts)
                 {
                     // Deserialize scripts
-                    ScriptAction = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptAction), version);
-                    ScriptAppear = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptAppear), version);
+                    ScriptAction = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptAction));
+                    ScriptAppear = instream.ReadNestedObjectProperty<ScriptData>(nameof(ScriptAppear));
 
                     // Correct script names
                     if (ScriptAction != null)
@@ -418,7 +418,7 @@ namespace Finmer.Core.Assets
                         {
                             // Read this child node
                             var child = new SceneNode();
-                            child.Deserialize(instream, version);
+                            child.Deserialize(instream);
                             child.Parent = this;
                             Children.Add(child);
                         }

--- a/Finmer.Core/Assets/AssetScript.cs
+++ b/Finmer.Core/Assets/AssetScript.cs
@@ -52,12 +52,12 @@ namespace Finmer.Core.Assets
             outstream.EndArray();
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
 
             // Read script data
-            Contents = instream.ReadNestedObjectProperty<ScriptData>(nameof(Contents), version);
+            Contents = instream.ReadNestedObjectProperty<ScriptData>(nameof(Contents));
             if (Contents != null)
                 Contents.Name = Name;
 

--- a/Finmer.Core/Assets/AssetStringTable.cs
+++ b/Finmer.Core/Assets/AssetStringTable.cs
@@ -54,9 +54,9 @@ namespace Finmer.Core.Assets
             outstream.EndArray(); // Entries
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
 
             Table = new StringTable();
 

--- a/Finmer.Core/Assets/ScriptData.cs
+++ b/Finmer.Core/Assets/ScriptData.cs
@@ -34,7 +34,7 @@ namespace Finmer.Core.Assets
 
         public abstract void Serialize(IFurballContentWriter outstream);
 
-        public abstract void Deserialize(IFurballContentReader instream, int version);
+        public abstract void Deserialize(IFurballContentReader instream);
 
     }
 

--- a/Finmer.Core/Assets/ScriptDataExternal.cs
+++ b/Finmer.Core/Assets/ScriptDataExternal.cs
@@ -30,7 +30,7 @@ namespace Finmer.Core.Assets
             outstream.WriteAttachment(GetScriptAttachmentName(), source_utf8);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Look for an attachment file
             Name = instream.ReadStringProperty("Name");

--- a/Finmer.Core/Assets/ScriptDataInline.cs
+++ b/Finmer.Core/Assets/ScriptDataInline.cs
@@ -38,7 +38,7 @@ namespace Finmer.Core.Assets
             outstream.WriteStringProperty("Script", ScriptText);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Note: Name is implicit for inline scripts so it does not need to be read or written
 

--- a/Finmer.Core/Assets/ScriptDataVisualAction.cs
+++ b/Finmer.Core/Assets/ScriptDataVisualAction.cs
@@ -59,11 +59,11 @@ namespace Finmer.Core.Assets
             outstream.EndArray();
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Recursively deserialize each of the nodes in the node array
             for (int i = 0, count = instream.BeginArray("Nodes"); i < count; i++)
-                Nodes.Add(instream.ReadNestedObjectProperty<ScriptNode>(null, version));
+                Nodes.Add(instream.ReadNestedObjectProperty<ScriptNode>(null));
             instream.EndArray();
         }
 

--- a/Finmer.Core/Assets/ScriptDataVisualCondition.cs
+++ b/Finmer.Core/Assets/ScriptDataVisualCondition.cs
@@ -54,9 +54,9 @@ namespace Finmer.Core.Assets
             Condition.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Condition.Deserialize(instream, version);
+            Condition.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/Assets/ScriptDataWrapper.cs
+++ b/Finmer.Core/Assets/ScriptDataWrapper.cs
@@ -37,10 +37,10 @@ namespace Finmer.Core.Assets
             Wrapped.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Forward deserialization call
-            Wrapped.Deserialize(instream, version);
+            Wrapped.Deserialize(instream);
         }
 
         public override string GetScriptText(IContentStore content)

--- a/Finmer.Core/Buffs/Buff.cs
+++ b/Finmer.Core/Buffs/Buff.cs
@@ -37,7 +37,7 @@ namespace Finmer.Core.Buffs
 
         public virtual void Serialize(IFurballContentWriter outstream) {}
 
-        public virtual void Deserialize(IFurballContentReader instream, int version) {}
+        public virtual void Deserialize(IFurballContentReader instream) {}
 
     }
 

--- a/Finmer.Core/Buffs/EquipEffectGroup.cs
+++ b/Finmer.Core/Buffs/EquipEffectGroup.cs
@@ -123,7 +123,7 @@ namespace Finmer.Core.Buffs
             outstream.EndArray();
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             // Group type
             ProcStyle = instream.ReadEnumProperty<EProcStyle>(nameof(ProcStyle));
@@ -139,7 +139,7 @@ namespace Finmer.Core.Buffs
 
             // Buff collection
             for (int i = 0, c = instream.BeginArray(nameof(Buffs)); i < c; i++)
-                Buffs.Add(instream.ReadNestedObjectProperty<Buff>(null, version));
+                Buffs.Add(instream.ReadNestedObjectProperty<Buff>(null));
             instream.EndArray();
         }
 

--- a/Finmer.Core/Buffs/MiscBuffs.cs
+++ b/Finmer.Core/Buffs/MiscBuffs.cs
@@ -97,7 +97,7 @@ namespace Finmer.Core.Buffs
             outstream.WriteStringProperty(nameof(TooltipText), TooltipText);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             TooltipText = instream.ReadStringProperty(nameof(TooltipText));
         }

--- a/Finmer.Core/Buffs/SingleDeltaBuff.cs
+++ b/Finmer.Core/Buffs/SingleDeltaBuff.cs
@@ -27,7 +27,7 @@ namespace Finmer.Core.Buffs
             outstream.WriteInt32Property("Delta", Delta);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Delta = instream.ReadInt32Property("Delta");
         }

--- a/Finmer.Core/Serialization/AssetSerializer.cs
+++ b/Finmer.Core/Serialization/AssetSerializer.cs
@@ -58,7 +58,7 @@ namespace Finmer.Core.Serialization
         /// <summary>
         /// Instantiates and deserializes an asset from the input stream.
         /// </summary>
-        public static IFurballSerializable DeserializeAsset(IFurballContentReader instream, int version)
+        public static IFurballSerializable DeserializeAsset(IFurballContentReader instream)
         {
             // Obtain the ctor for this object
             // Admittedly doing this explicit type check is a hack, but since the type ID is internal to AssetSerializer to begin
@@ -77,7 +77,7 @@ namespace Finmer.Core.Serialization
             var asset = constructor();
 
             // Read its data from stream
-            asset.Deserialize(instream, version);
+            asset.Deserialize(instream);
 
             return asset;
         }
@@ -123,7 +123,7 @@ namespace Finmer.Core.Serialization
                 using (var reader = new BinaryReader(ms, Encoding.UTF8, true))
                 {
                     var deserializer = new FurballContentReaderBinary(reader, FurballFileDevice.k_LatestVersion);
-                    return (TAsset)DeserializeAsset(deserializer, FurballFileDevice.k_LatestVersion);
+                    return (TAsset)DeserializeAsset(deserializer);
                 }
             }
         }

--- a/Finmer.Core/Serialization/FurballContentReaderBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentReaderBinary.cs
@@ -20,17 +20,17 @@ namespace Finmer.Core.Serialization
     {
 
         private readonly BinaryReader m_Stream;
-        private readonly int m_Version;
+        private readonly int m_FormatVersion;
 
-        public FurballContentReaderBinary(BinaryReader instream, int version)
+        public FurballContentReaderBinary(BinaryReader instream, int format_version)
         {
             m_Stream = instream;
-            m_Version = version;
+            m_FormatVersion = format_version;
         }
 
-        public int GetVersion()
+        public int GetFormatVersion()
         {
-            return m_Version;
+            return m_FormatVersion;
         }
 
         public bool ReadBooleanProperty(string key)
@@ -151,7 +151,7 @@ namespace Finmer.Core.Serialization
         private int Read7BitEncodedInt()
         {
             // In versions 20 and below, these were plain uncompressed integers
-            if (m_Version < 21)
+            if (m_FormatVersion < 21)
                 return m_Stream.ReadInt32();
 
             // The following is a re-implementation of Read7BitEncodedInt() from BinaryReader

--- a/Finmer.Core/Serialization/FurballContentReaderBinary.cs
+++ b/Finmer.Core/Serialization/FurballContentReaderBinary.cs
@@ -28,6 +28,11 @@ namespace Finmer.Core.Serialization
             m_Version = version;
         }
 
+        public int GetVersion()
+        {
+            return m_Version;
+        }
+
         public bool ReadBooleanProperty(string key)
         {
             return m_Stream.ReadBoolean();
@@ -96,7 +101,7 @@ namespace Finmer.Core.Serialization
             return m_Stream.ReadBytes(length);
         }
 
-        public TExpected ReadNestedObjectProperty<TExpected>( string key, int version) where TExpected : class, IFurballSerializable
+        public TExpected ReadNestedObjectProperty<TExpected>(string key) where TExpected : class, IFurballSerializable
         {
             // A single byte indicates whether the asset is null or not
             bool is_present = m_Stream.ReadBoolean();
@@ -104,7 +109,7 @@ namespace Finmer.Core.Serialization
                 return null;
 
             // It is present, so recursively deserialize it
-            var asset = AssetSerializer.DeserializeAsset(this, version);
+            var asset = AssetSerializer.DeserializeAsset(this);
             if (!(asset is TExpected expected))
                 // Error handling here to remove boilerplate from callers
                 throw new FurballInvalidAssetException($"Unexpected nested asset type in property '{key}'");

--- a/Finmer.Core/Serialization/FurballFileDeviceBinary.cs
+++ b/Finmer.Core/Serialization/FurballFileDeviceBinary.cs
@@ -189,7 +189,7 @@ namespace Finmer.Core.Serialization
         {
             // Deserialize an asset of the appropriate type
             IFurballContentReader content_reader = new FurballContentReaderBinary(instream, version);
-            AssetBase asset = AssetSerializer.DeserializeAsset(content_reader, version) as AssetBase;
+            AssetBase asset = AssetSerializer.DeserializeAsset(content_reader) as AssetBase;
             if (asset == null)
                 throw new FurballInvalidAssetException("Could not parse asset in stream");
 

--- a/Finmer.Core/Serialization/IFurballContentReader.cs
+++ b/Finmer.Core/Serialization/IFurballContentReader.cs
@@ -22,6 +22,11 @@ namespace Finmer.Core.Serialization
     {
 
         /// <summary>
+        /// Returns the format version of the module file being read.
+        /// </summary>
+        int GetVersion();
+
+        /// <summary>
         /// Read the value of a boolean property.
         /// </summary>
         /// <param name="key">The key of the key/value pair, to be used in content formats that support named keys.</param>
@@ -79,8 +84,7 @@ namespace Finmer.Core.Serialization
         /// Recursively deserializes a nested asset, or returns null if it is unset.
         /// </summary>
         /// <param name="key">The key of the key/value pair, to be used in content formats that support named keys.</param>
-        /// <param name="version">Furball file format version that the object is expected to be stored in.</param>
-        TExpected ReadNestedObjectProperty<TExpected>(string key, int version) where TExpected : class, IFurballSerializable;
+        TExpected ReadNestedObjectProperty<TExpected>(string key) where TExpected : class, IFurballSerializable;
 
         /// <summary>
         /// Reads a raw string token from the stream, such as an array element.

--- a/Finmer.Core/Serialization/IFurballContentReader.cs
+++ b/Finmer.Core/Serialization/IFurballContentReader.cs
@@ -24,7 +24,7 @@ namespace Finmer.Core.Serialization
         /// <summary>
         /// Returns the format version of the module file being read.
         /// </summary>
-        int GetVersion();
+        int GetFormatVersion();
 
         /// <summary>
         /// Read the value of a boolean property.

--- a/Finmer.Core/Serialization/IFurballSerializable.cs
+++ b/Finmer.Core/Serialization/IFurballSerializable.cs
@@ -23,7 +23,7 @@ namespace Finmer.Core.Serialization
         /// <summary>
         /// Load the object from an asset stream, overwriting existing instance data.
         /// </summary>
-        void Deserialize(IFurballContentReader instream, int version);
+        void Deserialize(IFurballContentReader instream);
 
     }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandCombatApplyBuff.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandCombatApplyBuff.cs
@@ -100,14 +100,14 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteCompressedInt32Property(nameof(Duration), Duration);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Target = instream.ReadEnumProperty<ETarget>(nameof(Target));
 
             if (Target == ETarget.NPC)
                 ParticipantID = instream.ReadStringProperty(nameof(ParticipantID));
 
-            Effect = instream.ReadNestedObjectProperty<Buff>(nameof(Effect), version);
+            Effect = instream.ReadNestedObjectProperty<Buff>(nameof(Effect));
             Duration = instream.ReadCompressedInt32Property(nameof(Duration));
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandCombatBegin.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandCombatBegin.cs
@@ -187,7 +187,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             SerializeOptionalSubgroup(outstream, nameof(CallbackCreatureReleased), CallbackCreatureReleased);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Basic configuration
             IncludePlayer = instream.ReadBooleanProperty(nameof(IncludePlayer));
@@ -208,14 +208,14 @@ namespace Finmer.Core.VisualScripting.Nodes
             instream.EndArray();
 
             // Callback bodies
-            CallbackCombatStart = DeserializeOptionalSubgroup(instream, version, nameof(CallbackCombatStart));
-            if (version >= 20)
-                CallbackRoundStart = DeserializeOptionalSubgroup(instream, version, nameof(CallbackRoundStart));
-            CallbackRoundEnd = DeserializeOptionalSubgroup(instream, version, nameof(CallbackRoundEnd));
-            CallbackPlayerKilled = DeserializeOptionalSubgroup(instream, version, nameof(CallbackPlayerKilled));
-            CallbackCreatureKilled = DeserializeOptionalSubgroup(instream, version, nameof(CallbackCreatureKilled));
-            CallbackCreatureVored = DeserializeOptionalSubgroup(instream, version, nameof(CallbackCreatureVored));
-            CallbackCreatureReleased = DeserializeOptionalSubgroup(instream, version, nameof(CallbackCreatureReleased));
+            CallbackCombatStart = DeserializeOptionalSubgroup(instream, nameof(CallbackCombatStart));
+            if (instream.GetVersion() >= 20)
+                CallbackRoundStart = DeserializeOptionalSubgroup(instream, nameof(CallbackRoundStart));
+            CallbackRoundEnd = DeserializeOptionalSubgroup(instream, nameof(CallbackRoundEnd));
+            CallbackPlayerKilled = DeserializeOptionalSubgroup(instream, nameof(CallbackPlayerKilled));
+            CallbackCreatureKilled = DeserializeOptionalSubgroup(instream, nameof(CallbackCreatureKilled));
+            CallbackCreatureVored = DeserializeOptionalSubgroup(instream, nameof(CallbackCreatureVored));
+            CallbackCreatureReleased = DeserializeOptionalSubgroup(instream, nameof(CallbackCreatureReleased));
         }
 
         public override IEnumerable<Subgroup> GetSubgroups()
@@ -289,7 +289,7 @@ namespace Finmer.Core.VisualScripting.Nodes
                 SerializeSubgroup(outstream, name, nodes);
         }
 
-        private List<ScriptNode> DeserializeOptionalSubgroup(IFurballContentReader instream, int version, string name)
+        private List<ScriptNode> DeserializeOptionalSubgroup(IFurballContentReader instream, string name)
         {
             // Read the presence flag
             bool has_callback = instream.ReadBooleanProperty("Has" + name);
@@ -297,7 +297,7 @@ namespace Finmer.Core.VisualScripting.Nodes
                 return null;
 
             // If callback exists, deserialize the subgroup
-            return DeserializeSubgroup(instream, version, name);
+            return DeserializeSubgroup(instream, name);
         }
 
         private void EmitCallbackFunction(StringBuilder output, IContentStore content, string name, List<ScriptNode> body)

--- a/Finmer.Core/VisualScripting/Nodes/CommandCombatBegin.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandCombatBegin.cs
@@ -209,7 +209,7 @@ namespace Finmer.Core.VisualScripting.Nodes
 
             // Callback bodies
             CallbackCombatStart = DeserializeOptionalSubgroup(instream, nameof(CallbackCombatStart));
-            if (instream.GetVersion() >= 20)
+            if (instream.GetFormatVersion() >= 20)
                 CallbackRoundStart = DeserializeOptionalSubgroup(instream, nameof(CallbackRoundStart));
             CallbackRoundEnd = DeserializeOptionalSubgroup(instream, nameof(CallbackRoundEnd));
             CallbackPlayerKilled = DeserializeOptionalSubgroup(instream, nameof(CallbackPlayerKilled));

--- a/Finmer.Core/VisualScripting/Nodes/CommandCombatSetGrappled.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandCombatSetGrappled.cs
@@ -74,7 +74,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty(nameof(TargetName), TargetName);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Mode = instream.ReadEnumProperty<EMode>(nameof(Mode));
             InstigatorName = instream.ReadStringProperty(nameof(InstigatorName));

--- a/Finmer.Core/VisualScripting/Nodes/CommandCombatSetVored.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandCombatSetVored.cs
@@ -74,7 +74,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty(nameof(PreyName), PreyName);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Mode = instream.ReadEnumProperty<EMode>(nameof(Mode));
             PredatorName = instream.ReadStringProperty(nameof(PredatorName));

--- a/Finmer.Core/VisualScripting/Nodes/CommandComment.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandComment.cs
@@ -44,7 +44,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty("Comment", Comment);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Comment = instream.ReadStringProperty("Comment");
         }

--- a/Finmer.Core/VisualScripting/Nodes/CommandGrammarSetContext.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandGrammarSetContext.cs
@@ -60,7 +60,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         }
 
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
             CreatureGuid = instream.ReadGuidProperty(nameof(CreatureGuid));

--- a/Finmer.Core/VisualScripting/Nodes/CommandGrammarSetVariable.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandGrammarSetVariable.cs
@@ -52,10 +52,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandIf.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandIf.cs
@@ -84,18 +84,18 @@ namespace Finmer.Core.VisualScripting.Nodes
             base.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Configuration
-            Condition.Deserialize(instream, version);
+            Condition.Deserialize(instream);
             HasElseBranch = instream.ReadBooleanProperty("HasElseBranch");
 
             // Node subgroups
-            MainSubgroup = DeserializeSubgroup(instream, version, nameof(MainSubgroup));
+            MainSubgroup = DeserializeSubgroup(instream, nameof(MainSubgroup));
             if (HasElseBranch)
-                ElseSubgroup = DeserializeSubgroup(instream, version, nameof(ElseSubgroup));
+                ElseSubgroup = DeserializeSubgroup(instream, nameof(ElseSubgroup));
 
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
         }
 
         public override IEnumerable<Subgroup> GetSubgroups()

--- a/Finmer.Core/VisualScripting/Nodes/CommandInlineSnippet.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandInlineSnippet.cs
@@ -45,7 +45,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty("Snippet", Snippet);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Snippet = instream.ReadStringProperty("Snippet");
         }

--- a/Finmer.Core/VisualScripting/Nodes/CommandJournalClose.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandJournalClose.cs
@@ -54,7 +54,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteGuidProperty(nameof(JournalGuid), JournalGuid);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             JournalGuid = instream.ReadGuidProperty(nameof(JournalGuid));
         }

--- a/Finmer.Core/VisualScripting/Nodes/CommandJournalUpdate.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandJournalUpdate.cs
@@ -60,7 +60,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         }
 
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             JournalGuid = instream.ReadGuidProperty(nameof(JournalGuid));
             Stage = instream.ReadCompressedInt32Property(nameof(Stage));

--- a/Finmer.Core/VisualScripting/Nodes/CommandLog.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandLog.cs
@@ -53,7 +53,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteBooleanProperty("IsRaw", IsRaw);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Text = instream.ReadStringProperty("Text");
             IsRaw = instream.ReadBooleanProperty("IsRaw");

--- a/Finmer.Core/VisualScripting/Nodes/CommandLoop.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandLoop.cs
@@ -54,10 +54,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             base.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            LoopBody = DeserializeSubgroup(instream, version, nameof(LoopBody));
-            base.Deserialize(instream, version);
+            LoopBody = DeserializeSubgroup(instream, nameof(LoopBody));
+            base.Deserialize(instream);
         }
 
         public override IEnumerable<Subgroup> GetSubgroups()

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerAddAP.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerAddAP.cs
@@ -47,9 +47,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerAddXP.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerAddXP.cs
@@ -47,9 +47,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetEquipment.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetEquipment.cs
@@ -79,7 +79,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteGuidProperty(nameof(ItemGuid), ItemGuid);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             EquipSlot = instream.ReadEnumProperty<ESlot>(nameof(EquipSlot));
             ItemGuid = instream.ReadGuidProperty(nameof(ItemGuid));

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetHealth.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetHealth.cs
@@ -68,10 +68,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetItem.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetItem.cs
@@ -74,7 +74,7 @@ namespace Finmer.Core.VisualScripting.Nodes
                 outstream.WriteBooleanProperty(nameof(Quiet), Quiet);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ItemGuid = instream.ReadGuidProperty(nameof(ItemGuid));
             Add = instream.ReadBooleanProperty(nameof(Add));

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetMoney.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetMoney.cs
@@ -68,10 +68,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetName.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetName.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetSpecies.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetSpecies.cs
@@ -70,7 +70,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty(nameof(CoatAdjective), CoatAdjective.ToLowerInvariant());
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Singular = instream.ReadStringProperty(nameof(Singular));
             Plural = instream.ReadStringProperty(nameof(Plural));

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetStat.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetStat.cs
@@ -85,11 +85,11 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Stat = instream.ReadEnumProperty<EStat>(nameof(Stat));
             StatOperation = instream.ReadEnumProperty<EOperation>(nameof(StatOperation));
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandPreysense.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPreysense.cs
@@ -90,7 +90,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteGuidProperty(nameof(CreatureGuid), CreatureGuid);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Mode = (ESenseType)instream.ReadCompressedInt32Property(nameof(Mode));
             CreatureGuid = instream.ReadGuidProperty(nameof(CreatureGuid));

--- a/Finmer.Core/VisualScripting/Nodes/CommandSetInstruction.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandSetInstruction.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandSetInventoryEnabled.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandSetInventoryEnabled.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandSetLocation.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandSetLocation.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandSetScene.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandSetScene.cs
@@ -51,7 +51,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteGuidProperty(nameof(SceneGuid), SceneGuid);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             SceneGuid = instream.ReadGuidProperty(nameof(SceneGuid));
         }

--- a/Finmer.Core/VisualScripting/Nodes/CommandShop.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandShop.cs
@@ -108,7 +108,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.EndArray();
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             // Basic configuration
             Key = instream.ReadStringProperty(nameof(Key));

--- a/Finmer.Core/VisualScripting/Nodes/CommandSleep.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandSleep.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Seconds.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Seconds.Deserialize(instream, version);
+            Seconds.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandTimeAdvance.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandTimeAdvance.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Hours.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Hours.Deserialize(instream, version);
+            Hours.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandTimeSetHour.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandTimeSetHour.cs
@@ -46,9 +46,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             Hour.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Hour.Deserialize(instream, version);
+            Hour.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandVarSetFlag.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandVarSetFlag.cs
@@ -52,10 +52,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/CommandVarSetNumber.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandVarSetNumber.cs
@@ -162,7 +162,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             VariableName = instream.ReadStringProperty(nameof(VariableName));
             ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
 
-            if (HasRightOperand() || instream.GetVersion() < 20)
+            if (HasRightOperand() || instream.GetFormatVersion() < 20)
                 Value.Deserialize(instream);
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandVarSetNumber.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandVarSetNumber.cs
@@ -157,13 +157,13 @@ namespace Finmer.Core.VisualScripting.Nodes
                 Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
             ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
 
-            if (HasRightOperand() || version < 20)
-                Value.Deserialize(instream, version);
+            if (HasRightOperand() || instream.GetVersion() < 20)
+                Value.Deserialize(instream);
         }
 
         /// <summary>

--- a/Finmer.Core/VisualScripting/Nodes/CommandVarSetString.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandVarSetString.cs
@@ -52,10 +52,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Value.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            Value.Deserialize(instream, version);
+            Value.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionCombatParDead.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionCombatParDead.cs
@@ -45,7 +45,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty(nameof(ParticipantName), ParticipantName);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ParticipantName = instream.ReadStringProperty(nameof(ParticipantName));
         }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionCombatParGrappling.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionCombatParGrappling.cs
@@ -60,7 +60,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty(nameof(TargetName), TargetName);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ParticipantName = instream.ReadStringProperty(nameof(ParticipantName));
             TargetName = instream.ReadStringProperty(nameof(TargetName));

--- a/Finmer.Core/VisualScripting/Nodes/ConditionCombatParSwallowed.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionCombatParSwallowed.cs
@@ -60,7 +60,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty(nameof(PredatorName), PredatorName);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ParticipantName = instream.ReadStringProperty(nameof(ParticipantName));
             PredatorName = instream.ReadStringProperty(nameof(PredatorName));

--- a/Finmer.Core/VisualScripting/Nodes/ConditionInlineSnippet.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionInlineSnippet.cs
@@ -43,7 +43,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteStringProperty("Snippet", Snippet);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Snippet = instream.ReadStringProperty("Snippet");
         }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionPlayerEquipment.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionPlayerEquipment.cs
@@ -79,7 +79,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteGuidProperty(nameof(ItemGuid), ItemGuid);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ItemGuid = instream.ReadGuidProperty(nameof(ItemGuid));
         }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionPlayerHasItem.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionPlayerHasItem.cs
@@ -51,7 +51,7 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteGuidProperty(nameof(ItemGuid), ItemGuid);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             ItemGuid = instream.ReadGuidProperty(nameof(ItemGuid));
         }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionPlayerName.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionPlayerName.cs
@@ -52,9 +52,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteBooleanProperty(nameof(IsCaseSensitive), IsCaseSensitive);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Comparison.Deserialize(instream, version);
+            Comparison.Deserialize(instream);
             IsCaseSensitive = instream.ReadBooleanProperty(nameof(IsCaseSensitive));
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/ConditionPlayerSpecies.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionPlayerSpecies.cs
@@ -52,9 +52,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteBooleanProperty(nameof(IsCaseSensitive), IsCaseSensitive);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            Comparison.Deserialize(instream, version);
+            Comparison.Deserialize(instream);
             IsCaseSensitive = instream.ReadBooleanProperty(nameof(IsCaseSensitive));
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/ConditionPlayerStat.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionPlayerStat.cs
@@ -49,9 +49,9 @@ namespace Finmer.Core.VisualScripting.Nodes
             outstream.WriteEnumProperty("Stat", Stat);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
             Stat = instream.ReadEnumProperty<EStat>("Stat");
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/ConditionVarFlag.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionVarFlag.cs
@@ -51,10 +51,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Operand.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            Operand.Deserialize(instream, version);
+            Operand.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionVarNumber.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionVarNumber.cs
@@ -45,10 +45,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             base.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            base.Deserialize(instream, version);
+            base.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/Nodes/ConditionVarString.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionVarString.cs
@@ -51,10 +51,10 @@ namespace Finmer.Core.VisualScripting.Nodes
             Operand.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            Operand.Deserialize(instream, version);
+            Operand.Deserialize(instream);
         }
 
     }

--- a/Finmer.Core/VisualScripting/ScriptCommandContainer.cs
+++ b/Finmer.Core/VisualScripting/ScriptCommandContainer.cs
@@ -60,14 +60,14 @@ namespace Finmer.Core.VisualScripting
         /// <summary>
         /// Helper method for reading a subgroup from an input stream that was written using SerializeSubgroup().
         /// </summary>
-        protected List<ScriptNode> DeserializeSubgroup(IFurballContentReader instream, int version, string key)
+        protected List<ScriptNode> DeserializeSubgroup(IFurballContentReader instream, string key)
         {
             var count = instream.BeginArray(key);
             var output = new List<ScriptNode>(count);
 
             // Read the nested nodes
             for (int i = 0; i < count; i++)
-                output.Add(instream.ReadNestedObjectProperty<ScriptNode>(null, version));
+                output.Add(instream.ReadNestedObjectProperty<ScriptNode>(null));
             instream.EndArray();
 
             return output;

--- a/Finmer.Core/VisualScripting/ScriptConditionGroup.cs
+++ b/Finmer.Core/VisualScripting/ScriptConditionGroup.cs
@@ -83,13 +83,13 @@ namespace Finmer.Core.VisualScripting
             outstream.EndArray();
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             Mode = instream.ReadEnumProperty<EConditionMode>("Mode");
             Operand = instream.ReadBooleanProperty("Operand");
 
             for (int i = 0, c = instream.BeginArray("Tests"); i < c; i++)
-                Tests.Add(instream.ReadNestedObjectProperty<ScriptCondition>(null, version));
+                Tests.Add(instream.ReadNestedObjectProperty<ScriptCondition>(null));
             instream.EndArray();
         }
 

--- a/Finmer.Core/VisualScripting/ScriptConditionNumberComparison.cs
+++ b/Finmer.Core/VisualScripting/ScriptConditionNumberComparison.cs
@@ -85,10 +85,10 @@ namespace Finmer.Core.VisualScripting
             RightOperand.Serialize(outstream);
         }
 
-        public override void Deserialize(IFurballContentReader instream, int version)
+        public override void Deserialize(IFurballContentReader instream)
         {
             Operator = instream.ReadEnumProperty<EOperator>(nameof(Operator));
-            RightOperand.Deserialize(instream, version);
+            RightOperand.Deserialize(instream);
         }
 
         /// <summary>

--- a/Finmer.Core/VisualScripting/ScriptNode.cs
+++ b/Finmer.Core/VisualScripting/ScriptNode.cs
@@ -56,7 +56,7 @@ namespace Finmer.Core.VisualScripting
 
         public virtual void Serialize(IFurballContentWriter outstream) {}
 
-        public virtual void Deserialize(IFurballContentReader instream, int version) {}
+        public virtual void Deserialize(IFurballContentReader instream) {}
 
     }
 

--- a/Finmer.Core/VisualScripting/ValueWrapperBool.cs
+++ b/Finmer.Core/VisualScripting/ValueWrapperBool.cs
@@ -54,7 +54,7 @@ namespace Finmer.Core.VisualScripting
                 outstream.WriteStringProperty(nameof(OperandText), OperandText);
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             OperandMode = instream.ReadEnumProperty<EOperandMode>(nameof(OperandMode));
 

--- a/Finmer.Core/VisualScripting/ValueWrapperFloat.cs
+++ b/Finmer.Core/VisualScripting/ValueWrapperFloat.cs
@@ -54,7 +54,7 @@ namespace Finmer.Core.VisualScripting
                 outstream.WriteStringProperty(nameof(OperandText), OperandText);
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             OperandMode = instream.ReadEnumProperty<EOperandMode>(nameof(OperandMode));
 

--- a/Finmer.Core/VisualScripting/ValueWrapperInt.cs
+++ b/Finmer.Core/VisualScripting/ValueWrapperInt.cs
@@ -54,7 +54,7 @@ namespace Finmer.Core.VisualScripting
                 outstream.WriteStringProperty(nameof(OperandText), OperandText);
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             OperandMode = instream.ReadEnumProperty<EOperandMode>(nameof(OperandMode));
 

--- a/Finmer.Core/VisualScripting/ValueWrapperString.cs
+++ b/Finmer.Core/VisualScripting/ValueWrapperString.cs
@@ -45,7 +45,7 @@ namespace Finmer.Core.VisualScripting
             outstream.WriteStringProperty(nameof(OperandText), OperandText);
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             OperandMode = instream.ReadEnumProperty<EOperandMode>(nameof(OperandMode));
             OperandText = instream.ReadStringProperty(nameof(OperandText));

--- a/Finmer.Editor/AssetDummy.cs
+++ b/Finmer.Editor/AssetDummy.cs
@@ -23,7 +23,7 @@ namespace Finmer.Editor
             throw new NotSupportedException();
         }
 
-        public void Deserialize(IFurballContentReader instream, int version)
+        public void Deserialize(IFurballContentReader instream)
         {
             throw new NotSupportedException();
         }

--- a/Finmer.Editor/FurballContentReaderText.cs
+++ b/Finmer.Editor/FurballContentReaderText.cs
@@ -29,26 +29,26 @@ namespace Finmer.Editor
         private readonly DirectoryInfo m_SearchPath;
         private readonly Stack<JToken> m_TokenStack = new Stack<JToken>();
         private readonly Stack<JToken> m_ArrayStack = new Stack<JToken>();
-        private readonly int m_Version;
+        private readonly int m_FormatVersion;
         private JToken m_CurrentArrayElement;
 
-        public FurballContentReaderText(JObject root, DirectoryInfo searchPath, int version)
+        public FurballContentReaderText(JObject root, DirectoryInfo searchPath, int format_version)
         {
             m_SearchPath = searchPath;
             m_TokenStack.Push(root);
-            m_Version = version;
+            m_FormatVersion = format_version;
         }
 
         public FurballContentReaderText(JObject root, DirectoryInfo searchPath)
         {
             m_SearchPath = searchPath;
             m_TokenStack.Push(root);
-            m_Version = ReadInt32Property("FormatVersion");
+            m_FormatVersion = ReadInt32Property("FormatVersion");
         }
 
-        public int GetVersion()
+        public int GetFormatVersion()
         {
-            return m_Version;
+            return m_FormatVersion;
         }
 
         public bool ReadBooleanProperty(string key)

--- a/Finmer.Editor/FurballContentReaderText.cs
+++ b/Finmer.Editor/FurballContentReaderText.cs
@@ -13,7 +13,6 @@ using System.IO;
 using System.Linq;
 using Finmer.Core.Serialization;
 using Newtonsoft.Json.Linq;
-using static WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender;
 
 namespace Finmer.Editor
 {

--- a/Finmer.Editor/FurballContentReaderText.cs
+++ b/Finmer.Editor/FurballContentReaderText.cs
@@ -31,6 +31,12 @@ namespace Finmer.Editor
         private int m_FormatVersion;
         private JToken m_CurrentArrayElement;
 
+        /// <summary>
+        /// Constructs a new FurballContentReaderText.
+        /// </summary>
+        /// <param name="root">The JSON document that describes the asset file.</param>
+        /// <param name="searchPath">Directory to search for any external file references.</param>
+        /// <param name="format_version">Format version number.</param>
         public FurballContentReaderText(JObject root, DirectoryInfo searchPath, int format_version)
         {
             m_SearchPath = searchPath;
@@ -38,7 +44,11 @@ namespace Finmer.Editor
             m_FormatVersion = format_version;
         }
 
-        public static FurballContentReaderText ForProjectMetadata(JObject root)
+        /// <summary>
+        /// Constructs a new FurballContentReaderText using format version information from the specified project file.
+        /// </summary>
+        /// <param name="root">The JSON document that describes the project file.</param>
+        public static FurballContentReaderText FromProjectMetadata(JObject root)
         {
             var reader = new FurballContentReaderText(root, null, 0);
             reader.m_FormatVersion = reader.ReadInt32Property("FormatVersion");

--- a/Finmer.Editor/FurballContentReaderText.cs
+++ b/Finmer.Editor/FurballContentReaderText.cs
@@ -29,7 +29,7 @@ namespace Finmer.Editor
         private readonly DirectoryInfo m_SearchPath;
         private readonly Stack<JToken> m_TokenStack = new Stack<JToken>();
         private readonly Stack<JToken> m_ArrayStack = new Stack<JToken>();
-        private readonly int m_FormatVersion;
+        private int m_FormatVersion;
         private JToken m_CurrentArrayElement;
 
         public FurballContentReaderText(JObject root, DirectoryInfo searchPath, int format_version)
@@ -39,11 +39,11 @@ namespace Finmer.Editor
             m_FormatVersion = format_version;
         }
 
-        public FurballContentReaderText(JObject root, DirectoryInfo searchPath)
+        public static FurballContentReaderText ForProjectMetadata(JObject root)
         {
-            m_SearchPath = searchPath;
-            m_TokenStack.Push(root);
-            m_FormatVersion = ReadInt32Property("FormatVersion");
+            var reader = new FurballContentReaderText(root, null, 0);
+            reader.m_FormatVersion = reader.ReadInt32Property("FormatVersion");
+            return reader;
         }
 
         public int GetFormatVersion()

--- a/Finmer.Editor/FurballFileDeviceText.cs
+++ b/Finmer.Editor/FurballFileDeviceText.cs
@@ -33,7 +33,7 @@ namespace Finmer.Editor
                 using (var json_stream = new JsonTextReader(read_stream))
                 {
                     // Read the project version number
-                    var header_reader = FurballContentReaderText.ForProjectMetadata(JObject.Load(json_stream));
+                    var header_reader = FurballContentReaderText.FromProjectMetadata(JObject.Load(json_stream));
                     var project_version = header_reader.GetFormatVersion();
 
                     // Validate that the version is within supported range
@@ -99,7 +99,7 @@ namespace Finmer.Editor
                 using (var read_stream = new StreamReader(file_stream, Encoding.UTF8))
                 using (var json_stream = new JsonTextReader(read_stream))
                 {
-                    var header_reader = FurballContentReaderText.ForProjectMetadata(JObject.Load(json_stream));
+                    var header_reader = FurballContentReaderText.FromProjectMetadata(JObject.Load(json_stream));
                     return new FurballMetadata
                     {
                         ID = header_reader.ReadGuidProperty("ID"),

--- a/Finmer.Editor/FurballFileDeviceText.cs
+++ b/Finmer.Editor/FurballFileDeviceText.cs
@@ -34,7 +34,7 @@ namespace Finmer.Editor
                 {
                     // Read the project version number
                     var header_reader = new FurballContentReaderText(JObject.Load(json_stream), null);
-                    var project_version = header_reader.GetVersion();
+                    var project_version = header_reader.GetFormatVersion();
 
                     // Validate that the version is within supported range
                     if (project_version < k_MinimumVersion)
@@ -105,7 +105,7 @@ namespace Finmer.Editor
                         ID = header_reader.ReadGuidProperty("ID"),
                         Title = header_reader.ReadStringProperty("Title"),
                         Author = header_reader.ReadStringProperty("Author"),
-                        FormatVersion = header_reader.GetVersion()
+                        FormatVersion = header_reader.GetFormatVersion()
                     };
                 }
             }

--- a/Finmer.Editor/FurballFileDeviceText.cs
+++ b/Finmer.Editor/FurballFileDeviceText.cs
@@ -34,7 +34,7 @@ namespace Finmer.Editor
                 {
                     // Read the project version number
                     var header_reader = new FurballContentReaderText(JObject.Load(json_stream), null);
-                    var project_version = header_reader.ReadInt32Property("FormatVersion");
+                    var project_version = header_reader.GetVersion();
 
                     // Validate that the version is within supported range
                     if (project_version < k_MinimumVersion)
@@ -105,7 +105,7 @@ namespace Finmer.Editor
                         ID = header_reader.ReadGuidProperty("ID"),
                         Title = header_reader.ReadStringProperty("Title"),
                         Author = header_reader.ReadStringProperty("Author"),
-                        FormatVersion = header_reader.ReadInt32Property("FormatVersion")
+                        FormatVersion = header_reader.GetVersion()
                     };
                 }
             }
@@ -122,10 +122,10 @@ namespace Finmer.Editor
             using (var json_stream = new JsonTextReader(read_stream))
             {
                 // Wrap a filesystem-agnostic reader around the json object
-                var content_reader = new FurballContentReaderText(JObject.Load(json_stream), GetProjectDirectory(file));
+                var content_reader = new FurballContentReaderText(JObject.Load(json_stream), GetProjectDirectory(file), version);
 
                 // Deserialize the asset
-                AssetBase asset = AssetSerializer.DeserializeAsset(content_reader, version) as AssetBase;
+                AssetBase asset = AssetSerializer.DeserializeAsset(content_reader) as AssetBase;
                 if (asset == null)
                     throw new FurballInvalidAssetException("Could not parse asset in stream");
 

--- a/Finmer.Editor/FurballFileDeviceText.cs
+++ b/Finmer.Editor/FurballFileDeviceText.cs
@@ -33,7 +33,7 @@ namespace Finmer.Editor
                 using (var json_stream = new JsonTextReader(read_stream))
                 {
                     // Read the project version number
-                    var header_reader = new FurballContentReaderText(JObject.Load(json_stream), null);
+                    var header_reader = FurballContentReaderText.ForProjectMetadata(JObject.Load(json_stream));
                     var project_version = header_reader.GetFormatVersion();
 
                     // Validate that the version is within supported range
@@ -99,7 +99,7 @@ namespace Finmer.Editor
                 using (var read_stream = new StreamReader(file_stream, Encoding.UTF8))
                 using (var json_stream = new JsonTextReader(read_stream))
                 {
-                    var header_reader = new FurballContentReaderText(JObject.Load(json_stream), null);
+                    var header_reader = FurballContentReaderText.ForProjectMetadata(JObject.Load(json_stream));
                     return new FurballMetadata
                     {
                         ID = header_reader.ReadGuidProperty("ID"),

--- a/Finmer.Game/Gameplay/SaveData.cs
+++ b/Finmer.Game/Gameplay/SaveData.cs
@@ -143,7 +143,7 @@ namespace Finmer.Gameplay
                 {
                     // Reconstruct and deserialize the asset
                     var reader = new FurballContentReaderBinary(br, FurballFileDevice.k_LatestVersion);
-                    var result = AssetSerializer.DeserializeAsset(reader, FurballFileDevice.k_LatestVersion) as TAsset;
+                    var result = AssetSerializer.DeserializeAsset(reader) as TAsset;
 
                     // If casting failed, the asset was of some unexpected type
                     if (result == null)


### PR DESCRIPTION
So here's the previously-mentioned format version refactor, with surprisingly fewer changed files than I was expecting. As described, it yeets the version parameter from basically every method that had it and introduces an accessor on the reader instead. The text reader was a bit of a chicken-and-egg situation though -- the previous code needed the reader to read the format version, but now the reader needs the format version immediately. I addressed that by introducing an overload which grabs the version from itself (which *probably* won't cause problems).

Something I did notice while changing the 70 some `Deserialize()` implementations is that some of them don't use `nameof` and rather hard-code the name directly (see `ConditionInlineSnippet`, for example). (This is excluding ones where the string differs from the name, or where it's like, an array access.) Would you like me to change those while I'm touching these files or should I leave them as is?

Oh yeah, another thing: is there any particular reason the version is passed around as an `int`, but read/written as a `byte` (in the binary format)? Is it just to avoid extra casts?