### PR TITLE
Turn all `int` enums into `byte` ones

### DIFF
--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetEquipment.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetEquipment.cs
@@ -24,7 +24,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Describes an equipment slot.
         /// </summary>
-        public enum ESlot
+        public enum ESlot : byte
         {
             Weapon,
             Armor,
@@ -81,7 +81,7 @@ namespace Finmer.Core.VisualScripting.Nodes
 
         public override void Deserialize(IFurballContentReader instream)
         {
-            EquipSlot = instream.ReadEnumProperty<ESlot>(nameof(EquipSlot));
+            EquipSlot = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<ESlot>(nameof(EquipSlot)) : (ESlot)instream.ReadInt32Property(nameof(EquipSlot));
             ItemGuid = instream.ReadGuidProperty(nameof(ItemGuid));
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetHealth.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetHealth.cs
@@ -23,7 +23,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Describes what to do with the value.
         /// </summary>
-        public enum EOperation
+        public enum EOperation : byte
         {
             Add,
             Set
@@ -70,7 +70,7 @@ namespace Finmer.Core.VisualScripting.Nodes
 
         public override void Deserialize(IFurballContentReader instream)
         {
-            ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
+            ValueOperation = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EOperation>(nameof(ValueOperation)) : (EOperation)instream.ReadInt32Property(nameof(ValueOperation));
             Value.Deserialize(instream);
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetMoney.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetMoney.cs
@@ -23,7 +23,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Describes what to do with the value.
         /// </summary>
-        public enum EOperation
+        public enum EOperation : byte
         {
             Add,
             Set
@@ -70,7 +70,7 @@ namespace Finmer.Core.VisualScripting.Nodes
 
         public override void Deserialize(IFurballContentReader instream)
         {
-            ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
+            ValueOperation = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EOperation>(nameof(ValueOperation)) : (EOperation)instream.ReadInt32Property(nameof(ValueOperation));
             Value.Deserialize(instream);
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetStat.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandPlayerSetStat.cs
@@ -23,7 +23,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Describes the stat to influence.
         /// </summary>
-        public enum EStat
+        public enum EStat : byte
         {
             Strength,
             Agility,
@@ -34,7 +34,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Describes what to do with the stat.
         /// </summary>
-        public enum EOperation
+        public enum EOperation : byte
         {
             Add,
             Set
@@ -87,8 +87,8 @@ namespace Finmer.Core.VisualScripting.Nodes
 
         public override void Deserialize(IFurballContentReader instream)
         {
-            Stat = instream.ReadEnumProperty<EStat>(nameof(Stat));
-            StatOperation = instream.ReadEnumProperty<EOperation>(nameof(StatOperation));
+            Stat = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EStat>(nameof(Stat)) : (EStat)instream.ReadInt32Property(nameof(Stat));
+            StatOperation = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EOperation>(nameof(StatOperation)) : (EOperation)instream.ReadInt32Property(nameof(StatOperation));
             Value.Deserialize(instream);
         }
 

--- a/Finmer.Core/VisualScripting/Nodes/CommandVarSetNumber.cs
+++ b/Finmer.Core/VisualScripting/Nodes/CommandVarSetNumber.cs
@@ -23,7 +23,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Describes what to do with the value.
         /// </summary>
-        public enum EOperation
+        public enum EOperation : byte
         {
             Add,
             Multiply,
@@ -160,7 +160,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         public override void Deserialize(IFurballContentReader instream)
         {
             VariableName = instream.ReadStringProperty(nameof(VariableName));
-            ValueOperation = instream.ReadEnumProperty<EOperation>(nameof(ValueOperation));
+            ValueOperation = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EOperation>(nameof(ValueOperation)) : (EOperation)instream.ReadInt32Property(nameof(ValueOperation));
 
             if (HasRightOperand() || instream.GetFormatVersion() < 20)
                 Value.Deserialize(instream);

--- a/Finmer.Core/VisualScripting/Nodes/ConditionPlayerStat.cs
+++ b/Finmer.Core/VisualScripting/Nodes/ConditionPlayerStat.cs
@@ -20,7 +20,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         /// <summary>
         /// Identifies a primary stat.
         /// </summary>
-        public enum EStat
+        public enum EStat : byte
         {
             Strength,
             Agility,
@@ -52,7 +52,7 @@ namespace Finmer.Core.VisualScripting.Nodes
         public override void Deserialize(IFurballContentReader instream)
         {
             base.Deserialize(instream);
-            Stat = instream.ReadEnumProperty<EStat>("Stat");
+            Stat = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EStat>(nameof(Stat)) : (EStat)instream.ReadInt32Property(nameof(Stat));
         }
 
         protected override string GetLeftOperandExpression()

--- a/Finmer.Core/VisualScripting/ScriptConditionGroup.cs
+++ b/Finmer.Core/VisualScripting/ScriptConditionGroup.cs
@@ -22,7 +22,7 @@ namespace Finmer.Core.VisualScripting
         /// <summary>
         /// Describes the conjunction mode for combining multiple conditions.
         /// </summary>
-        public enum EConditionMode
+        public enum EConditionMode : byte
         {
             All,
             Any
@@ -85,7 +85,7 @@ namespace Finmer.Core.VisualScripting
 
         public void Deserialize(IFurballContentReader instream)
         {
-            Mode = instream.ReadEnumProperty<EConditionMode>("Mode");
+            Mode = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EConditionMode>(nameof(Mode)) : (EConditionMode)instream.ReadInt32Property(nameof(Mode));
             Operand = instream.ReadBooleanProperty("Operand");
 
             for (int i = 0, c = instream.BeginArray("Tests"); i < c; i++)

--- a/Finmer.Core/VisualScripting/ScriptConditionNumberComparison.cs
+++ b/Finmer.Core/VisualScripting/ScriptConditionNumberComparison.cs
@@ -22,7 +22,7 @@ namespace Finmer.Core.VisualScripting
         /// <summary>
         /// Describes how two operands should be compared.
         /// </summary>
-        public enum EOperator
+        public enum EOperator : byte
         {
             Equal,
             NotEqual,
@@ -87,7 +87,7 @@ namespace Finmer.Core.VisualScripting
 
         public override void Deserialize(IFurballContentReader instream)
         {
-            Operator = instream.ReadEnumProperty<EOperator>(nameof(Operator));
+            Operator = instream.GetFormatVersion() >= 21 ? instream.ReadEnumProperty<EOperator>(nameof(Operator)) : (EOperator)instream.ReadInt32Property(nameof(Operator));
             RightOperand.Deserialize(instream);
         }
 


### PR DESCRIPTION
This PR reduces the size of certain `int`-sized enums by making them `byte`-sized ones instead.